### PR TITLE
fixes & improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Jekyll::Linkpreview
 
-Jekyll plugin to generate link preview by `{% linkpreview %}` tag. The plugin fetches [Open Graph protocols](http://ogp.me/) of the designated page to generate preview. The og properties are saved as JSON for caching and it is used when rebuilding the site.
+Jekyll plugin to generate link preview by `{% linkpreview %}` tag. The plugin fetches [Open Graph Protocol](http://ogp.me/) metadata of the designated page to generate preview. The og properties are saved as JSON for caching and it is used when rebuilding the site.
 
 You can pass url directly to the tag,
 
 ```
-{% linkpreview https://github.com %}
+{% linkpreview "https://github.com" %}
 ```
 
 or, can pass a url variable.
@@ -60,6 +60,32 @@ See https://jekyllrb.com/docs/plugins/installation/ .
 1. Use `{% linkpreview %}` tag.
 
 1. Run `jekyll build` or `jekyll serve`.
+
+
+## Preview templates
+
+You can override the default templates used for generating previews, both in case Open Graph Protocol metadata exists or does not exist for a given page.
+
+### Open Graph Protocol preview template
+
+Template used for generating previews for pages where Open Graph Protocol metadata **exists**.
+
+ 1. Place `linkpreview.html` file inside `_includes/` folder of your Jekyll site (`_includes/linkpreview.html`)
+
+ 2. Use built-in variables to extract data which you would like to render. Available variables are:
+  * **link_url** i.e. `{{ link_url }}`
+  * **link_title** i.e. `{{ link_title }}`
+  * **link_image** i.e. `{{ link_image }}`
+  * **link_description** i.e. `{{ link_description }}`
+  * **link_domain** i.e. `{{ link_domain }}`
+
+### No Open Graph Protocol preview template
+
+Template used for generating previews for pages where Open Graph Protocol metadata **does not exist**.
+
+1. Place `linkpreview_nog.html` file inside `_includes/` folder of your Jekyll site (`_includes/linkpreview_nog.html`)
+
+2. Use built-in **link_url** variable to render URL data, i.e. `{{ link_url }}`
 
 ## Development
 

--- a/jekyll-linkpreview.gemspec
+++ b/jekyll-linkpreview.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |spec|
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
   spec.require_paths = ["lib"]
-
-  spec.add_dependency "jekyll", "~> 3.5"
+  
+  spec.add_dependency "jekyll", "~> 3.8.6"
   spec.add_dependency "metainspector"
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/jekyll-linkpreview/version.rb
+++ b/lib/jekyll-linkpreview/version.rb
@@ -1,5 +1,5 @@
 module Jekyll
   module Linkpreview
-    VERSION = "0.2.0"
+    VERSION = "0.3.0"
   end
 end

--- a/spec/jekyll-linkpreview_spec.rb
+++ b/spec/jekyll-linkpreview_spec.rb
@@ -189,7 +189,7 @@ RSpec.describe "Integration test" do
   context "when URL is directly passed to the tag" do
     it "can generate link preview" do
       t = Liquid::Template.new
-      t.parse("{% test_linkpreview https://github.com %}")
+      t.parse('{% test_linkpreview "https://github.com" %}')
       expect(t.render).not_to include('Liquid error: internal')
     end
   end


### PR DESCRIPTION
Hi, 

I just committed few fixes and improvements which I needed to make. Those are: 

1. FIX: file not being closed 
In `lib/jekyll-linkpreview.rb`, function `save_cache_file` had a problem due to file not being closed. This error could be seen on first generation / when no cache entry existed for given URL and attempt to create then read cache entry for given URL was made.

2. FIX: variable not being extracted properly 
This error prevented me from passing URLs as variables to the linkpreview tag. Now either string or a variable can be passed with no problems.

3. IMPROVEMENT: ability to customize layout via template - instead of using those embedded in plugin source code
More information about this in code and the updated README.md file.

4. Other: 
* updated 'spec/jekyll-linkpreview_spec.rb'
* bumped 'lib/jekyll-linkpreview/version.rb' to version 0.3.0
* bumped 'jekyll-linkpreview.gemspec' jekyll version to '3.8.6'
* updated 'README.md'


Some of these fixes and improvements actually coinicide with issues I noticed you had open, which you can now close, i.e.: 
 * https://github.com/ysk24ok/jekyll-linkpreview/issues/2
 * https://github.com/ysk24ok/jekyll-linkpreview/issues/3

Regards,
Michael