### PR TITLE
Let extract_domain return nil when url is ill-formed

### DIFF
--- a/lib/jekyll-linkpreview.rb
+++ b/lib/jekyll-linkpreview.rb
@@ -51,7 +51,11 @@ module Jekyll
         if url.nil? then
           return nil
         end
-        url.match(%r{(http|https)://([^/]+).*})[-1]
+        m = url.match(%r{(http|https)://([^/]+).*})
+        if m.nil? then
+          return nil
+        end
+        m[-1]
       end
     end
 

--- a/spec/jekyll-linkpreview_spec.rb
+++ b/spec/jekyll-linkpreview_spec.rb
@@ -85,6 +85,20 @@ RSpec.describe 'Jekyll::Linkpreview::OpenGraphProperties' do
         end
       end
 
+      context "when 'og:url' tag has ill-formed URL" do
+        before do
+          allow(@og_properties).to receive(:fetch).and_return({
+            'og:url' => ['ill-formed']
+          })
+        end
+
+        it 'cannot extract url and domain' do
+          properties = @og_properties.get(nil)
+          expect(properties['url']).to eq 'ill-formed'
+          expect(properties['domain']).to eq nil
+        end
+      end
+
       context "when 'og:url' tag has no content" do
         before do
           allow(@og_properties).to receive(:fetch).and_return({})


### PR DESCRIPTION
fix #12 