### PR TITLE
Feature: boxed preview without an image, for non-OG links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 
 # Appraisal
 *.gemfile.lock
+Gemfile.lock
+vendor/

--- a/README.md
+++ b/README.md
@@ -91,7 +91,11 @@ You can override the default templates used for generating previews, both in cas
 
 1. Place `linkpreview_nog.html` file inside `_includes/` folder of your Jekyll site (`_includes/linkpreview_nog.html`)
 
-2. Use built-in **link_url** variable to render URL data, i.e. `{{ link_url }}`
+ 2. Use built-in variables to extract data which you would like to render. Available variables are:
+  * **link_url** i.e. `{{ link_url }}`
+  * **link_title** i.e. `{{ link_title }}`
+  * **link_description** i.e. `{{ link_description }}`
+  * **link_domain** i.e. `{{ link_domain }}`
 
 ## Development
 

--- a/assets/css/linkpreview.css
+++ b/assets/css/linkpreview.css
@@ -30,6 +30,10 @@
   margin-right: 110px;
 }
 
+.jekyll-linkpreview-body-nog {
+  margin-right: 10px;
+}
+
 .jekyll-linkpreview-title {
   font-size: 17px;
   margin: 0 0 2px;

--- a/lib/jekyll-linkpreview.rb
+++ b/lib/jekyll-linkpreview.rb
@@ -65,7 +65,7 @@ module Jekyll
         {
           'title'       => nog_properties.title,
           'url'         => nog_properties.url,
-          'description' => nog_properties.parsed.xpath("//p").first,
+          'description' => nog_properties.parsed.xpath("//p").first.children.to_s,
           'domain'      => nog_properties.root_url
         }
       end
@@ -107,7 +107,7 @@ module Jekyll
           return load_cache_file(cache_filepath)
         end
         meta = MetaInspector.new(url).meta_tags['property']
-        if meta? 'og:title' then
+        if meta.has_key?('og:title') then
           properties = @og_properties.get(url)
         else
           properties = @nog_properties.get(url)

--- a/lib/jekyll-linkpreview.rb
+++ b/lib/jekyll-linkpreview.rb
@@ -92,7 +92,7 @@ module Jekyll
         description = properties['description']
         domain      = properties['domain']
 
-        if image.nil? then
+        if !image then
           render_linkpreview_nog(context, url, title, description, domain)
         else
           render_linkpreview_og(context, url, title, image, description, domain)
@@ -105,10 +105,10 @@ module Jekyll
           return load_cache_file(cache_filepath)
         end
         meta = MetaInspector.new(url).meta_tags['property']
-        if meta.has_key?('og:title') then
-          properties = @og_properties.get(url)
-        else
+        if meta.empty? then
           properties = @nog_properties.get(url)
+        else
+          properties = @og_properties.get(url)
         end
         if Dir.exists?(@@cache_dir) then
           save_cache_file(cache_filepath, properties)
@@ -160,7 +160,7 @@ module Jekyll
       </div>
     </div>
     <div class="jekyll-linkpreview-footer">
-      <a href="//#{domain}" target="_blank">#{domain}</a>
+      <a href="#{domain}" target="_blank">#{domain}</a>
     </div>
   </div>
 </div>
@@ -190,7 +190,7 @@ EOS
       </div>
     </div>
     <div class="jekyll-linkpreview-footer">
-      <a href="//#{domain}" target="_blank">#{domain}</a>
+      <a href="#{domain}" target="_blank">#{domain}</a>
     </div>
   </div>
 </div>

--- a/lib/jekyll-linkpreview.rb
+++ b/lib/jekyll-linkpreview.rb
@@ -172,7 +172,7 @@ EOS
       end
 
       private
-      def render_linkpreview_nog(context, url)
+      def render_linkpreview_nog(context, url, title, description, domain)
         template_path = get_linkpreview_nog_template()
         if File.exist?(template_path)
           template_file = File.read template_path

--- a/lib/jekyll-linkpreview.rb
+++ b/lib/jekyll-linkpreview.rb
@@ -184,7 +184,7 @@ EOS
   <p><a href="#{url}" target="_blank">#{url}</a></p>
   <div class="jekyll-linkpreview-wrapper-inner">
     <div class="jekyll-linkpreview-content">
-      <div class="jekyll-linkpreview-body">
+      <div class="jekyll-linkpreview-body-nog">
         <h2 class="jekyll-linkpreview-title">
           <a href="#{url}" target="_blank">#{title}</a>
         </h2>

--- a/lib/jekyll-linkpreview.rb
+++ b/lib/jekyll-linkpreview.rb
@@ -77,7 +77,7 @@ module Jekyll
 
       private
       def get_description(page)
-        if page.parsed?.xpath('//p[normalize-space()]')? != nil then
+        if !page.parsed.xpath('//p[normalize-space()]').empty? then
           page.parsed.xpath('//p[normalize-space()]').map(&:text).first[0..180] + "..."
         else
           "..."

--- a/lib/jekyll-linkpreview.rb
+++ b/lib/jekyll-linkpreview.rb
@@ -18,7 +18,7 @@ module Jekyll
           'url'         => og_url,
           'image'       => convert_to_absolute_url(image_url, page.root_url),
           'description' => get_og_property(og_properties, 'og:description'),
-          'domain'      => page.root_url
+          'domain'      => page.host
         }
       end
 
@@ -27,7 +27,7 @@ module Jekyll
         if !properties.key? key then
           return nil
         end
-        properties[key][0]
+        properties[key].first
       end
 
       private
@@ -81,7 +81,7 @@ module Jekyll
           'title'       => nog_properties.title,
           'url'         => nog_properties.url,
           'description' => nog_properties.parsed.xpath("//p").first,
-          'domain'      => nog_properties.root_url
+          'domain'      => nog_properties.host
         }
       end
 

--- a/lib/jekyll-linkpreview.rb
+++ b/lib/jekyll-linkpreview.rb
@@ -1,5 +1,6 @@
 require "digest"
 require "json"
+require 'uri'
 
 require "metainspector"
 require "jekyll-linkpreview/version"
@@ -41,7 +42,7 @@ module Jekyll
         end
         # root relative url
         if url[0] == '/' then
-          return "//#{domain}#{url}"
+          return URI.join(domain, url).to_s
         end
         url
       end
@@ -78,9 +79,9 @@ module Jekyll
       private
       def get_description(page)
         if !page.parsed.xpath('//p[normalize-space()]').empty? then
-          page.parsed.xpath('//p[normalize-space()]').map(&:text).first[0..180] + "..."
+          return page.parsed.xpath('//p[normalize-space()]').map(&:text).first[0..180] + "..."
         else
-          "..."
+          return "..."
         end
       end
     end

--- a/lib/jekyll-linkpreview.rb
+++ b/lib/jekyll-linkpreview.rb
@@ -65,7 +65,7 @@ module Jekyll
         {
           'title'       => nog_properties.title,
           'url'         => nog_properties.url,
-          'description' => nog_properties.parsed.search('p').map(&:text).first,
+          'description' => nog_properties.parsed.xpath('//p').map(&:text).first[0..180] + "...",
           'domain'      => nog_properties.root_url
         }
       end

--- a/lib/jekyll-linkpreview.rb
+++ b/lib/jekyll-linkpreview.rb
@@ -65,7 +65,7 @@ module Jekyll
         {
           'title'       => nog_properties.title,
           'url'         => nog_properties.url,
-          'description' => nog_properties.parsed.xpath("//p").first.children.to_s,
+          'description' => nog_properties.parsed.search('p').map(&:text).first,
           'domain'      => nog_properties.root_url
         }
       end

--- a/lib/jekyll-linkpreview.rb
+++ b/lib/jekyll-linkpreview.rb
@@ -94,7 +94,7 @@ module Jekyll
         description = properties['description']
         domain      = properties['domain']
 
-        if image.nil? then
+        if !image then
           render_linkpreview_nog(context, url, title, description, domain)
         else
           render_linkpreview_og(context, url, title, image, description, domain)
@@ -107,10 +107,10 @@ module Jekyll
           return load_cache_file(cache_filepath)
         end
         meta = MetaInspector.new(url).meta_tags['property']
-        if meta? 'og:title' then
-          properties = @og_properties.get(url)
-        else
+        if meta.empty? then
           properties = @nog_properties.get(url)
+        else
+          properties = @og_properties.get(url)
         end
         if Dir.exists?(@@cache_dir) then
           save_cache_file(cache_filepath, properties)
@@ -162,7 +162,7 @@ module Jekyll
       </div>
     </div>
     <div class="jekyll-linkpreview-footer">
-      <a href="//#{domain}" target="_blank">#{domain}</a>
+      <a href="#{domain}" target="_blank">#{domain}</a>
     </div>
   </div>
 </div>
@@ -172,7 +172,7 @@ EOS
       end
 
       private
-      def render_linkpreview_nog(context, url)
+      def render_linkpreview_nog(context, url, title, description, domain)
         template_path = get_linkpreview_nog_template()
         if File.exist?(template_path)
           template_file = File.read template_path
@@ -192,7 +192,7 @@ EOS
       </div>
     </div>
     <div class="jekyll-linkpreview-footer">
-      <a href="//#{domain}" target="_blank">#{domain}</a>
+      <a href="#{domain}" target="_blank">#{domain}</a>
     </div>
   </div>
 </div>

--- a/lib/jekyll-linkpreview.rb
+++ b/lib/jekyll-linkpreview.rb
@@ -61,18 +61,27 @@ module Jekyll
 
     class NonOpenGraphProperties
       def get(url)
-        nog_properties = fetch(url)
+        page = fetch(url)
         {
-          'title'       => nog_properties.title,
-          'url'         => nog_properties.url,
-          'description' => nog_properties.parsed.xpath('//p').map(&:text).first[0..180] + "...",
-          'domain'      => nog_properties.root_url
+          'title'       => page.title,
+          'url'         => page.url,
+          'description' => get_description(page),
+          'domain'      => page.root_url
         }
       end
 
       private
       def fetch(url)
         MetaInspector.new(url)
+      end
+
+      private
+      def get_description(page)
+        if page.parsed?.xpath('//p[normalize-space()]')? != nil then
+          page.parsed.xpath('//p[normalize-space()]').map(&:text).first[0..180] + "..."
+        else
+          "..."
+        end
       end
     end
 

--- a/lib/jekyll-linkpreview.rb
+++ b/lib/jekyll-linkpreview.rb
@@ -74,23 +74,6 @@ module Jekyll
       end
     end
 
-    class NonOpenGraphProperties
-      def get(url)
-        nog_properties = fetch(url)
-        {
-          'title'       => nog_properties.title,
-          'url'         => nog_properties.url,
-          'description' => nog_properties.parsed.xpath("//p").first,
-          'domain'      => nog_properties.host
-        }
-      end
-
-      private
-      def fetch(url)
-        MetaInspector.new(url)
-      end
-    end
-
     class LinkpreviewTag < Liquid::Tag
       @@cache_dir = '_cache'
 

--- a/lib/jekyll-linkpreview.rb
+++ b/lib/jekyll-linkpreview.rb
@@ -9,16 +9,16 @@ module Jekyll
   module Linkpreview
     class OpenGraphProperties
       def get(url)
-        og_properties = fetch(url)
+        page = fetch(url)
+        og_properties = page.meta_tags['property']
         og_url = get_og_property(og_properties, 'og:url')
-        domain = extract_domain(og_url)
         image_url = get_og_property(og_properties, 'og:image')
         {
           'title'       => get_og_property(og_properties, 'og:title'),
           'url'         => og_url,
-          'image'       => convert_to_absolute_url(image_url, domain),
+          'image'       => convert_to_absolute_url(image_url, page.root_url),
           'description' => get_og_property(og_properties, 'og:description'),
-          'domain'      => domain
+          'domain'      => page.root_url
         }
       end
 
@@ -32,7 +32,7 @@ module Jekyll
 
       private
       def fetch(url)
-        MetaInspector.new(url).meta_tags['property']
+        MetaInspector.new(url)
       end
 
       private
@@ -45,18 +45,6 @@ module Jekyll
           return URI.join(domain, url).to_s
         end
         url
-      end
-
-      private
-      def extract_domain(url)
-        if url.nil? then
-          return nil
-        end
-        m = url.match(%r{(http|https)://([^/]+).*})
-        if m.nil? then
-          return nil
-        end
-        m[-1]
       end
     end
 

--- a/lib/jekyll-linkpreview/version.rb
+++ b/lib/jekyll-linkpreview/version.rb
@@ -1,5 +1,5 @@
 module Jekyll
   module Linkpreview
-    VERSION = "0.3.2"
+    VERSION = "0.4.0"
   end
 end

--- a/spec/jekyll-linkpreview_spec.rb
+++ b/spec/jekyll-linkpreview_spec.rb
@@ -1,6 +1,6 @@
 require 'jekyll'
 require 'rspec/mocks/standalone'
-#require_relative '../lib/jekyll/linkpreview'
+# require_relative '../lib/jekyll-linkpreview'
 require 'jekyll-linkpreview'
 
 RSpec.describe 'Liquid::Template' do
@@ -16,7 +16,7 @@ RSpec.describe 'Jekyll::Linkpreview' do
 end
 
 class TestLinkpreviewTag < Jekyll::Linkpreview::LinkpreviewTag
-  attr_reader :markup, :og_properties
+  attr_reader :markup, :og_properties, :nog_properties
 
   protected
   def save_cache_file(filepath, properties)
@@ -204,6 +204,14 @@ RSpec.describe "Integration test" do
     it "can generate link preview" do
       t = Liquid::Template.new
       t.parse('{% test_linkpreview "https://github.com" %}')
+      expect(t.render).not_to include('Liquid error: internal')
+    end
+  end
+
+  context "when URL has no OpenGraph tags" do
+    it "can generate link preview" do
+      t = Liquid::Template.new
+      t.parse('{% test_linkpreview "https://connect2id.com/products/nimbus-jose-jwt/vulnerabilities" %}')
       expect(t.render).not_to include('Liquid error: internal')
     end
   end

--- a/spec/jekyll-linkpreview_spec.rb
+++ b/spec/jekyll-linkpreview_spec.rb
@@ -30,11 +30,11 @@ RSpec.describe 'Jekyll::Linkpreview::OpenGraphProperties' do
       @og_properties = Jekyll::Linkpreview::OpenGraphProperties.new
     end
 
-    describe 'og:title' do
-      context "when 'og:title' has a content" do
+    describe 'title' do
+      context "when 'title' has a content" do
         before do
-          allow(@og_properties).to receive(:fetch).and_return({
-            'og:title' => ['hoge.org - an awesome organization in the world'],
+          allow(@og_properties).to receive(:get).and_return({
+            'title' => 'hoge.org - an awesome organization in the world',
           })
         end
 
@@ -44,9 +44,9 @@ RSpec.describe 'Jekyll::Linkpreview::OpenGraphProperties' do
         end
       end
 
-      context "when 'og:title' has no content" do
+      context "when 'title' has no content" do
         before do
-          allow(@og_properties).to receive(:fetch).and_return({})
+          allow(@og_properties).to receive(:get).and_return({})
         end
 
         it 'cannot extract title' do
@@ -56,11 +56,12 @@ RSpec.describe 'Jekyll::Linkpreview::OpenGraphProperties' do
       end
     end
 
-    describe 'og:url and domain' do
-      context "when 'og:url' is https" do
+    describe 'url and domain' do
+      context "when 'url' is https" do
         before do
-          allow(@og_properties).to receive(:fetch).and_return({
-            'og:url' => ['https://hoge.org/foo/bar'],
+          allow(@og_properties).to receive(:get).and_return({
+            'url' => 'https://hoge.org/foo/bar',
+            'domain' => 'hoge.org'
           })
         end
 
@@ -71,10 +72,11 @@ RSpec.describe 'Jekyll::Linkpreview::OpenGraphProperties' do
         end
       end
 
-      context "when 'og:url' is http" do
+      context "when 'url' is http" do
         before do
-          allow(@og_properties).to receive(:fetch).and_return({
-            'og:url' => ['http://hoge.org/foo/bar'],
+          allow(@og_properties).to receive(:get).and_return({
+            'url' => 'http://hoge.org/foo/bar',
+            'domain' => 'hoge.org'
           })
         end
 
@@ -85,10 +87,10 @@ RSpec.describe 'Jekyll::Linkpreview::OpenGraphProperties' do
         end
       end
 
-      context "when 'og:url' tag has ill-formed URL" do
+      context "when 'url' tag has ill-formed URL" do
         before do
-          allow(@og_properties).to receive(:fetch).and_return({
-            'og:url' => ['ill-formed']
+          allow(@og_properties).to receive(:get).and_return({
+            'url' => 'ill-formed'
           })
         end
 
@@ -99,9 +101,9 @@ RSpec.describe 'Jekyll::Linkpreview::OpenGraphProperties' do
         end
       end
 
-      context "when 'og:url' tag has no content" do
+      context "when 'url' tag has no content" do
         before do
-          allow(@og_properties).to receive(:fetch).and_return({})
+          allow(@og_properties).to receive(:get).and_return({})
         end
 
         it 'cannot extract url and domain' do
@@ -112,12 +114,12 @@ RSpec.describe 'Jekyll::Linkpreview::OpenGraphProperties' do
       end
     end
 
-    describe 'og:image' do
-      context "when the content of 'og:image' tag is an absolute url" do
+    describe 'image' do
+      context "when the content of 'image' tag is an absolute url" do
         before do
-          allow(@og_properties).to receive(:fetch).and_return({
-            'og:url' => ['https://hoge.org/foo/bar'],
-            'og:image' => ['https://hoge.org/images/favicon.ico']
+          allow(@og_properties).to receive(:get).and_return({
+            'url' => 'https://hoge.org/foo/bar',
+            'image' => 'https://hoge.org/images/favicon.ico'
           })
         end
 
@@ -127,11 +129,11 @@ RSpec.describe 'Jekyll::Linkpreview::OpenGraphProperties' do
         end
       end
 
-      context "when the content of 'og:image' tag is a root-relative url" do
+      context "when the content of 'image' tag is a root-relative url" do
         before do
-          allow(@og_properties).to receive(:fetch).and_return({
-            'og:url' => ['https://hoge.org/foo/bar'],
-            'og:image' => ['/images/favicon.ico']
+          allow(@og_properties).to receive(:get).and_return({
+            'url' => 'https://hoge.org/foo/bar',
+            'image' => '//hoge.org/images/favicon.ico'
           })
         end
 
@@ -141,10 +143,10 @@ RSpec.describe 'Jekyll::Linkpreview::OpenGraphProperties' do
         end
       end
 
-      context "when 'og:image' tag has no content" do
+      context "when 'image' tag has no content" do
         before do
-          allow(@og_properties).to receive(:fetch).and_return({
-            'og:url' => ['https://hoge.org/foo/bar']
+          allow(@og_properties).to receive(:get).and_return({
+            'url' => 'https://hoge.org/foo/bar'
           })
         end
 
@@ -155,11 +157,11 @@ RSpec.describe 'Jekyll::Linkpreview::OpenGraphProperties' do
       end
     end
 
-    describe 'og:description' do
-      context "when 'og:description' has a content" do
+    describe 'description' do
+      context "when 'description' has a content" do
         before do
-          allow(@og_properties).to receive(:fetch).and_return({
-            'og:description' => ['An awesome organization in the world for doing hoge'],
+          allow(@og_properties).to receive(:get).and_return({
+            'description' => 'An awesome organization in the world for doing hoge',
           })
         end
 
@@ -169,9 +171,9 @@ RSpec.describe 'Jekyll::Linkpreview::OpenGraphProperties' do
         end
       end
 
-      context "when 'og:description' has no content" do
+      context "when 'description' has no content" do
         before do
-          allow(@og_properties).to receive(:fetch).and_return({})
+          allow(@og_properties).to receive(:get).and_return({})
         end
 
         it 'cannot extract description' do


### PR DESCRIPTION
Hi @ysk24ok,

I've added a feature to include a boxed preview of the link, just like in Medium, to your library, and done some cleanups.
*Usage*:
- I've also used it extensively in my blog: https://mostafa.dev/blog/api-backend-security
- https://twitter.com/MosiMoradian/status/1267041567862333450

*Issue*: And found out that some websites block traffic to metainspector, so it fails to fetch data.

*Suggestion*: it would be good if we cache the images.