### PR TITLE
Refactoring

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,14 @@
 FROM ruby:2.6.5
 
-RUN apt-get -y update
-RUN gem install jekyll bundler
+RUN apt update \
+ && apt install -y \
+    vim \
+ && rm -rf /var/lib/apt/lists/*
+RUN gem install \
+    bundler \
+    jekyll
+RUN mkdir /jekyll-linkpreview
+ADD Gemfile /jekyll-linkpreview
+ADD jekyll-linkpreview.gemspec /jekyll-linkpreview
+ADD lib/jekyll-linkpreview/version.rb /jekyll-linkpreview/lib/jekyll-linkpreview/version.rb
+RUN cd /jekyll-linkpreview && bundle install

--- a/README.md
+++ b/README.md
@@ -7,53 +7,23 @@ Jekyll plugin to generate link preview by `{% linkpreview %}` tag. The plugin fe
 You can pass url directly to the tag,
 
 ```
-{% linkpreview "https://github.com" %}
+{% linkpreview "https://github.com/ysk24ok/jekyll-linkpreview" %}
 ```
 
 or, can pass a url variable.
 
 ```
-{% assign github_toppage = 'https://github.com' %}
-{% linkpreview github_toppage %}
+{% assign jekyll_linkpreview_page = "https://github.com/ysk24ok/jekyll-linkpreview" %}
+{% linkpreview jekyll_linkpreview_page %}
 ```
 
-The tag above generates following HTML when you run `jekyll build`.
+By applying [linkpreview.css](assets/css/linkpreview.css), the link preview will be like this.
 
-```html
-<div class="jekyll-linkpreview-wrapper">
-  <p><a href="https://github.com" target="_blank">https://github.com</a></p>
-  <div class="jekyll-linkpreview-wrapper-inner">
-    <div class="jekyll-linkpreview-content">
-      <div class="jekyll-linkpreview-image">
-        <a href="https://github.com" target="_blank">
-          <img src="https://github.githubassets.com/images/modules/open_graph/github-logo.png" />
-        </a>
-      </div>
-      <div class="jekyll-linkpreview-body">
-        <h2 class="jekyll-linkpreview-title">
-          <a href="https://github.com" target="_blank">Build software better, together</a>
-        </h2>
-        <div class="jekyll-linkpreview-description">GitHub is where people build software. More than 31 million people use GitHub to discover, fork, and contribute to over 100 million projects.</div>
-      </div>
-    </div>
-    <div class="jekyll-linkpreview-footer">
-      <a href="https://github.com" target="_blank">github.com</a>
-    </div>
-  </div>
-</div>
-```
+<img width="613" alt="スクリーンショット 2020-10-26 19 10 26" src="https://user-images.githubusercontent.com/3449164/97160548-db472f80-17bf-11eb-9cc2-383a076fb14d.png">
 
-By applying appropriate CSS, the link preview will be like this.
+When the page does not have Open Graph protocol metadata, the preview will be like this.
 
-<img width="613" alt="スクリーンショット 2019-04-03 20 52 50" src="https://user-images.githubusercontent.com/3449164/55479970-35baf100-565a-11e9-8c5d-709213917f74.png">
-
-When the page does not have Open Graph protocol metadata, following simple HTML will be generated.
-
-```html
-<div class="jekyll-linkpreview-wrapper">
-  <p><a href="https://example.com" target="_blank">https://example.com</a></p>
-</div>
-```
+<img width="613" alt="スクリーンショット 2020-10-26 19 10 35" src="https://user-images.githubusercontent.com/3449164/97160564-e00be380-17bf-11eb-8adb-55c2a07520f1.png">
 
 You can override the default templates, see [Custom templates](#user-content-custom-templates).
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,39 @@ After checking out the repo, run `bin/setup` to install dependencies. Then, run 
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
+### Test with Jekyll site
+
+First, build a Docker image and run a container.
+
+```console
+$ docker build --no-cache -t jekyll_linkpreview_dev .
+$ docker run --rm -it -w /jekyll-linkpreview -p 4000:4000 jekyll_linkpreview_dev /bin/bash
+```
+
+Create a new Jekyll site and move into the new directory.
+
+```console
+# bundle exec jekyll new testsite && cd testsite
+```
+
+Add this line to `:jekyll_plugins` group of Gemfile.
+
+```console
+gem "jekyll-linkpreview", git: "https://github.com/YOUR_ACCOUNT/jekyll-linkpreview", branch: "YOUR_BRANCH"
+```
+
+Install the dependecies to your new site.
+
+```console
+# bundle install
+```
+
+Add a tag such as `{% linkpreview "https://github.com/ysk24ok/jekyll-linkpreview" %}` to `index.markdown` , then start a Jekyll server.
+
+```console
+# bundle exec jekyll serve --host 0.0.0.0
+```
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/ysk24ok/jekyll-linkpreview.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Jekyll::Linkpreview
 
-[![Build Status](https://travis-ci.org/ysk24ok/jekyll-linkpreview.svg?branch=master)](https://travis-ci.org/ysk24ok/jekyll-linkpreview)
+[![Build Status](https://travis-ci.com/ysk24ok/jekyll-linkpreview.svg?branch=master)](https://travis-ci.com/ysk24ok/jekyll-linkpreview)
 
 Jekyll plugin to generate link preview by `{% linkpreview %}` tag. The plugin fetches [Open Graph protocol](http://ogp.me/) metadata of the designated page to generate preview. The og properties are saved as JSON for caching and it is used when rebuilding the site.
 

--- a/lib/jekyll-linkpreview.rb
+++ b/lib/jekyll-linkpreview.rb
@@ -48,6 +48,10 @@ EOS
         html
       end
 
+      def get_custom_template_path()
+        File.join Dir.pwd, "_includes", "linkpreview.html"
+      end
+
       private
       def get_og_property(properties, key)
         if !properties.key? key then
@@ -99,6 +103,10 @@ EOS
 </div>
 EOS
         html
+      end
+
+      def get_custom_template_path()
+        File.join Dir.pwd, "_includes", "linkpreview_nog.html"
       end
 
       private
@@ -178,7 +186,7 @@ EOS
 
       private
       def render_linkpreview_og(context, url, title, image, description, domain)
-        template_path = get_linkpreview_og_template()
+        template_path = @og_properties.get_custom_template_path()
         if File.exist?(template_path)
           template_file = File.read template_path
           site = context.registers[:site]
@@ -190,7 +198,7 @@ EOS
 
       private
       def render_linkpreview_nog(context, url, title, description, domain)
-        template_path = get_linkpreview_nog_template()
+        template_path = @nog_properties.get_custom_template_path()
         if File.exist?(template_path)
           template_file = File.read template_path
           site = context.registers[:site]
@@ -198,16 +206,6 @@ EOS
         else
           @nog_properties.gen_default_template(url, title, description, domain)
         end
-      end
-
-      private
-      def get_linkpreview_og_template()
-        File.join Dir.pwd, "_includes", "linkpreview.html"
-      end
-
-      private
-      def get_linkpreview_nog_template()
-        File.join Dir.pwd, "_includes", "linkpreview_nog.html"
       end
     end
   end

--- a/lib/jekyll-linkpreview.rb
+++ b/lib/jekyll-linkpreview.rb
@@ -8,8 +8,7 @@ require "jekyll-linkpreview/version"
 module Jekyll
   module Linkpreview
     class OpenGraphProperties
-      def get(url)
-        page = fetch(url)
+      def get(page)
         og_properties = page.meta_tags['property']
         og_url = get_og_property(og_properties, 'og:url')
         image_url = get_og_property(og_properties, 'og:image')
@@ -31,11 +30,6 @@ module Jekyll
       end
 
       private
-      def fetch(url)
-        MetaInspector.new(url)
-      end
-
-      private
       def convert_to_absolute_url(url, domain)
         if url.nil? then
           return nil
@@ -49,19 +43,13 @@ module Jekyll
     end
 
     class NonOpenGraphProperties
-      def get(url)
-        page = fetch(url)
+      def get(page)
         {
           'title'       => page.title,
           'url'         => page.url,
           'description' => get_description(page),
           'domain'      => page.root_url
         }
-      end
-
-      private
-      def fetch(url)
-        MetaInspector.new(url)
       end
 
       private
@@ -104,11 +92,11 @@ module Jekyll
         if File.exist?(cache_filepath) then
           return load_cache_file(cache_filepath)
         end
-        meta = MetaInspector.new(url).meta_tags['property']
-        if meta.empty? then
-          properties = @nog_properties.get(url)
+        page = fetch(url)
+        if page.meta_tags['property'].empty? then
+          properties = @nog_properties.get(page)
         else
-          properties = @og_properties.get(url)
+          properties = @og_properties.get(page)
         end
         if Dir.exists?(@@cache_dir) then
           save_cache_file(cache_filepath, properties)
@@ -122,6 +110,11 @@ module Jekyll
       private
       def get_url_from(context)
         context[@markup]
+      end
+
+      private
+      def fetch(url)
+        MetaInspector.new(url)
       end
 
       private

--- a/lib/jekyll-linkpreview.rb
+++ b/lib/jekyll-linkpreview.rb
@@ -21,6 +21,33 @@ module Jekyll
         }
       end
 
+      def gen_default_template(url, title, image, description, domain)
+        html = <<-EOS
+<div class="jekyll-linkpreview-wrapper">
+  <p><a href="#{url}" target="_blank">#{url}</a></p>
+  <div class="jekyll-linkpreview-wrapper-inner">
+    <div class="jekyll-linkpreview-content">
+      <div class="jekyll-linkpreview-image">
+        <a href="#{url}" target="_blank">
+          <img src="#{image}" />
+        </a>
+      </div>
+      <div class="jekyll-linkpreview-body">
+        <h2 class="jekyll-linkpreview-title">
+          <a href="#{url}" target="_blank">#{title}</a>
+        </h2>
+        <div class="jekyll-linkpreview-description">#{description}</div>
+      </div>
+    </div>
+    <div class="jekyll-linkpreview-footer">
+      <a href="#{domain}" target="_blank">#{domain}</a>
+    </div>
+  </div>
+</div>
+EOS
+        html
+      end
+
       private
       def get_og_property(properties, key)
         if !properties.key? key then
@@ -50,6 +77,28 @@ module Jekyll
           'description' => get_description(page),
           'domain'      => page.root_url
         }
+      end
+
+      def gen_default_template(url, title, description, domain)
+        html = <<-EOS
+<div class="jekyll-linkpreview-wrapper">
+  <p><a href="#{url}" target="_blank">#{url}</a></p>
+  <div class="jekyll-linkpreview-wrapper-inner">
+    <div class="jekyll-linkpreview-content">
+      <div class="jekyll-linkpreview-body">
+        <h2 class="jekyll-linkpreview-title">
+          <a href="#{url}" target="_blank">#{title}</a>
+        </h2>
+        <div class="jekyll-linkpreview-description">#{description}</div>
+      </div>
+    </div>
+    <div class="jekyll-linkpreview-footer">
+      <a href="#{domain}" target="_blank">#{domain}</a>
+    </div>
+  </div>
+</div>
+EOS
+        html
       end
 
       private
@@ -135,30 +184,7 @@ module Jekyll
           site = context.registers[:site]
           template_file = (Liquid::Template.parse template_file).render site.site_payload.merge!({"link_url" => url, "link_title" => title, "link_image" => image, "link_description" => description, "link_domain" => domain})
         else
-          html = <<-EOS
-<div class="jekyll-linkpreview-wrapper">
-  <p><a href="#{url}" target="_blank">#{url}</a></p>
-  <div class="jekyll-linkpreview-wrapper-inner">
-    <div class="jekyll-linkpreview-content">
-      <div class="jekyll-linkpreview-image">
-        <a href="#{url}" target="_blank">
-          <img src="#{image}" />
-        </a>
-      </div>
-      <div class="jekyll-linkpreview-body">
-        <h2 class="jekyll-linkpreview-title">
-          <a href="#{url}" target="_blank">#{title}</a>
-        </h2>
-        <div class="jekyll-linkpreview-description">#{description}</div>
-      </div>
-    </div>
-    <div class="jekyll-linkpreview-footer">
-      <a href="#{domain}" target="_blank">#{domain}</a>
-    </div>
-  </div>
-</div>
-EOS
-          html
+          @og_properties.gen_default_template(url, title, image, description, domain)
         end
       end
 
@@ -170,25 +196,7 @@ EOS
           site = context.registers[:site]
           template_file = (Liquid::Template.parse template_file).render site.site_payload.merge!({"link_url" => url, "link_title" => title, "link_description" => description, "link_domain" => domain})
         else
-          html = <<-EOS
-<div class="jekyll-linkpreview-wrapper">
-  <p><a href="#{url}" target="_blank">#{url}</a></p>
-  <div class="jekyll-linkpreview-wrapper-inner">
-    <div class="jekyll-linkpreview-content">
-      <div class="jekyll-linkpreview-body">
-        <h2 class="jekyll-linkpreview-title">
-          <a href="#{url}" target="_blank">#{title}</a>
-        </h2>
-        <div class="jekyll-linkpreview-description">#{description}</div>
-      </div>
-    </div>
-    <div class="jekyll-linkpreview-footer">
-      <a href="#{domain}" target="_blank">#{domain}</a>
-    </div>
-  </div>
-</div>
-EOS
-          html
+          @nog_properties.gen_default_template(url, title, description, domain)
         end
       end
 

--- a/lib/jekyll-linkpreview.rb
+++ b/lib/jekyll-linkpreview.rb
@@ -31,38 +31,6 @@ module Jekyll
         }
       end
 
-      def gen_default_template(properties)
-        title = properties['title'],
-        url = properties['url'],
-        image = properties['image'],
-        description = properties['description'],
-        domain = properties['domain']
-        html = <<-EOS
-<div class="jekyll-linkpreview-wrapper">
-  <p><a href="#{url}" target="_blank">#{url}</a></p>
-  <div class="jekyll-linkpreview-wrapper-inner">
-    <div class="jekyll-linkpreview-content">
-      <div class="jekyll-linkpreview-image">
-        <a href="#{url}" target="_blank">
-          <img src="#{image}" />
-        </a>
-      </div>
-      <div class="jekyll-linkpreview-body">
-        <h2 class="jekyll-linkpreview-title">
-          <a href="#{url}" target="_blank">#{title}</a>
-        </h2>
-        <div class="jekyll-linkpreview-description">#{description}</div>
-      </div>
-    </div>
-    <div class="jekyll-linkpreview-footer">
-      <a href="#{domain}" target="_blank">#{domain}</a>
-    </div>
-  </div>
-</div>
-EOS
-        html
-      end
-
       def get_custom_template_path()
         File.join Dir.pwd, "_includes", "linkpreview.html"
       end
@@ -105,32 +73,6 @@ EOS
           "link_description" => properties['description'],
           "link_domain" => properties['domain']
         }
-      end
-
-      def gen_default_template(properties)
-        title = properties['title'],
-        url = properties['url'],
-        description = properties['description'],
-        domain = properties['domain']
-        html = <<-EOS
-<div class="jekyll-linkpreview-wrapper">
-  <p><a href="#{url}" target="_blank">#{url}</a></p>
-  <div class="jekyll-linkpreview-wrapper-inner">
-    <div class="jekyll-linkpreview-content">
-      <div class="jekyll-linkpreview-body">
-        <h2 class="jekyll-linkpreview-title">
-          <a href="#{url}" target="_blank">#{title}</a>
-        </h2>
-        <div class="jekyll-linkpreview-description">#{description}</div>
-      </div>
-    </div>
-    <div class="jekyll-linkpreview-footer">
-      <a href="#{domain}" target="_blank">#{domain}</a>
-    </div>
-  </div>
-</div>
-EOS
-        html
       end
 
       def get_custom_template_path()
@@ -215,8 +157,47 @@ EOS
           link_properties = ogp.get_properties_for_custom_template properties
           gen_custom_template context template_path link_properties
         else
-          ogp.gen_default_template properties
+          gen_default_template properties
         end
+      end
+
+      private
+      def gen_default_template(properties)
+        title = properties['title']
+        url = properties['url']
+        description = properties['description']
+        domain = properties['domain']
+        image = properties['image']
+        image_html = ""
+        if image then
+          image_html = <<-EOS
+<div class="jekyll-linkpreview-image">
+  <a href="#{url}" target="_blank">
+    <img src="#{image}" />
+  </a>
+</div>
+EOS
+        end
+        html = <<-EOS
+<div class="jekyll-linkpreview-wrapper">
+  <p><a href="#{url}" target="_blank">#{url}</a></p>
+  <div class="jekyll-linkpreview-wrapper-inner">
+    <div class="jekyll-linkpreview-content">
+#{image_html}
+      <div class="jekyll-linkpreview-body">
+        <h2 class="jekyll-linkpreview-title">
+          <a href="#{url}" target="_blank">#{title}</a>
+        </h2>
+        <div class="jekyll-linkpreview-description">#{description}</div>
+      </div>
+    </div>
+    <div class="jekyll-linkpreview-footer">
+      <a href="#{domain}" target="_blank">#{domain}</a>
+    </div>
+  </div>
+</div>
+EOS
+        html
       end
 
       private


### PR DESCRIPTION
* Let factories create properties objects
  - `OpenGraphPropertiesFactory` creates `OpenGraphProperties`
  - `NonOpenGraphPropertiesFactory` creates `NonOpenGraphProperties`
* Let properties objects carry data
* Added an instruction for testing with Jekyll site
* Updated README