### PR TITLE
Use MetaInspector's best guess on page title when generating Non-OGP preview

### DIFF
--- a/lib/jekyll-linkpreview.rb
+++ b/lib/jekyll-linkpreview.rb
@@ -116,8 +116,8 @@ module Jekyll
 
     class NonOpenGraphPropertiesFactory
       def from_page(page)
-        NonOpenGraphProperties.new(
-          page.title, page.url, get_description(page), page.host)
+        title = page.title.empty? ? page.best_title : page.title
+        NonOpenGraphProperties.new(title, page.url, get_description(page), page.host)
       end
 
       def from_hash(hash)

--- a/lib/jekyll-linkpreview.rb
+++ b/lib/jekyll-linkpreview.rb
@@ -116,8 +116,7 @@ module Jekyll
 
     class NonOpenGraphPropertiesFactory
       def from_page(page)
-        title = page.title.empty? ? page.best_title : page.title
-        NonOpenGraphProperties.new(title, page.url, get_description(page), page.host)
+        NonOpenGraphProperties.new(page.best_title, page.url, get_description(page), page.host)
       end
 
       def from_hash(hash)

--- a/spec/jekyll-linkpreview_spec.rb
+++ b/spec/jekyll-linkpreview_spec.rb
@@ -481,10 +481,31 @@ RSpec.describe 'Jekyll::Linkpreview::NonOpenGraphPropertiesFactory' do
 </html>
 EOS
       )
+      @page_title_in_body = MetaInspector.new(
+        @url,
+        :document => <<-EOS
+<html>
+  <body>
+    <title>#{@title}</title>
+  </body>
+</html>
+      EOS
+      )
     end
 
-    it 'can return an instance of NonOpenGraphProperties' do
-      got = @factory.from_page(@page).to_hash
+    context 'when parsing well-written HTML' do
+      it 'can return an instance of NonOpenGraphProperties' do
+        check_properties(@factory.from_page(@page).to_hash)
+      end
+    end
+
+    context 'when parsing HTML whose title tag is in body' do
+      it 'can return an instance of NonOpenGraphProperties' do
+        check_properties(@factory.from_page(@page_title_in_body).to_hash)
+      end
+    end
+
+    def check_properties(got)
       expect(got['title']).to eq @title
       expect(got['url']).to eq @url
       expect(got['description']).to eq '...'


### PR DESCRIPTION
Closes #38.

This PR changes the behavior of `NonOpenGraphPropertiesFactory` so that the `title` can be found even if the page doesn't write its `<title>` within its `<head>`. To be specific, one of the following elements will be used as the page title (if more than one is found, the earliest in this list is used:)
* `<meta property='title' ...>`
* `<meta property='og:title' ...>`
* `<title>` within `<head>`
* `<title>` within `<body>`
* The first `<h1>` element within the page

