### PR TITLE
Fix CI failing because of old rubygems

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Install dependencies
-        run: bundle install
+        run: gem update && bundle install
       - name: Install dependencies for each appraisal
         run: bundle exec appraisal install
       - name: Run tests


### PR DESCRIPTION
Closes #40.

This patch adds `gem update` before `bundle install`, preventing errors related to old rubygems. On my side, the CI triggered on pushes seems to be running correctly.

I'm not sure if repository owners can accept this kind of PR from non-owners; if not, feel free to copy this patch and close this one.

(p.s., if you also want me to modify the CI so that we can see CI results here (per https://github.com/ysk24ok/jekyll-linkpreview/pull/39#issuecomment-1407357413) please tell me.)