### PR TITLE
Use Non-OGP template if any of required OG tags are missing from the page

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ You can override the default templates used for generating previews, both in cas
  2. Use built-in variables to extract data which you would like to render. Available variables are:
   * **link_url** i.e. `{{ link_url }}`
   * **link_title** i.e. `{{ link_title }}`
+  * **link_type** i.e. `{{ link_type }}`
   * **link_image** i.e. `{{ link_image }}`
   * **link_description** i.e. `{{ link_description }}`
   * **link_domain** i.e. `{{ link_domain }}`

--- a/lib/jekyll-linkpreview.rb
+++ b/lib/jekyll-linkpreview.rb
@@ -189,7 +189,9 @@ module Jekyll
 
       private
       def create_properties_from_page(page)
-        if page.meta_tags['property'].empty? then
+        if !%w[og:title og:type og:url og:image].all? { |required_tag|
+          page.meta_tags['property'].include?(required_tag)
+        }
           factory = NonOpenGraphPropertiesFactory.new
         else
           factory = OpenGraphPropertiesFactory.new

--- a/lib/jekyll-linkpreview.rb
+++ b/lib/jekyll-linkpreview.rb
@@ -10,8 +10,9 @@ module Jekyll
     class OpenGraphProperties
       @@template_file = 'linkpreview.html'
 
-      def initialize(title, url, image, description, domain)
+      def initialize(title, type, url, image, description, domain)
         @title = title
+        @type = type
         @url = url
         @image = image
         @description = description
@@ -21,6 +22,7 @@ module Jekyll
       def to_hash()
         {
           'title' => @title,
+          'type' => @type,
           'url' => @url,
           'image' => @image,
           'description' => @description,
@@ -31,6 +33,7 @@ module Jekyll
       def to_hash_for_custom_template()
         {
           'link_title' => @title,
+          'link_type' => @type,
           'link_url' => @url,
           'link_image' => @image,
           'link_description' => @description,
@@ -48,16 +51,17 @@ module Jekyll
         og_properties = page.meta_tags['property']
         image_url = get_og_property(og_properties, 'og:image')
         title = get_og_property(og_properties, 'og:title')
+        type = get_og_property(og_properties, 'og:type')
         url = get_og_property(og_properties, 'og:url')
         image = convert_to_absolute_url(image_url, page.root_url)
         description = get_og_property(og_properties, 'og:description')
         domain = page.host
-        OpenGraphProperties.new(title, url, image, description, domain)
+        OpenGraphProperties.new(title, type, url, image, description, domain)
       end
 
       def from_hash(hash)
         OpenGraphProperties.new(
-          hash['title'], hash['url'], hash['image'], hash['description'], hash['domain'])
+          hash['title'], hash['type'], hash['url'], hash['image'], hash['description'], hash['domain'])
       end
 
       private

--- a/spec/jekyll-linkpreview_spec.rb
+++ b/spec/jekyll-linkpreview_spec.rb
@@ -36,17 +36,19 @@ end
 RSpec.describe 'Jekyll::Linkpreview::OpenGraphProperties' do
   before do
     @title = 'awesome.org - an awesome organization in the world'
+    @type = 'website'
     @url = 'https://awesome.org/about'
     @image = 'https://awesome.org/images/favicon.ico'
     @description = 'An awesome organization in the world.'
     @domain = 'awesome.org'
-    @properties = Jekyll::Linkpreview::OpenGraphProperties.new @title, @url, @image, @description, @domain
+    @properties = Jekyll::Linkpreview::OpenGraphProperties.new @title, @type, @url, @image, @description, @domain
   end
 
   describe '#to_hash' do
     it 'can return hash' do
       got = @properties.to_hash
       expect(got['title']).to eq @title
+      expect(got['type']).to eq @type
       expect(got['url']).to eq @url
       expect(got['image']).to eq @image
       expect(got['description']).to eq @description
@@ -58,6 +60,7 @@ RSpec.describe 'Jekyll::Linkpreview::OpenGraphProperties' do
     it 'can return hash for custom template' do
       got = @properties.to_hash_for_custom_template
       expect(got['link_title']).to eq @title
+      expect(got['link_type']).to eq @type
       expect(got['link_url']).to eq @url
       expect(got['link_image']).to eq @image
       expect(got['link_description']).to eq @description
@@ -445,6 +448,7 @@ EOS
     before do
       @hash = {
         'title' => 'awesome.org - an awesome organization in the world',
+        'type' => 'website',
         'url' => 'https://awesome.org/about',
         'domain' => 'awesome.org',
         'image' => 'https://awesome.org/images/favicon.ico',
@@ -556,6 +560,7 @@ RSpec.describe 'Jekyll::Linkpreview::LinkpreviewTag' do
     describe '#render' do
       before do
         @title = 'awesome.org - an awesome organization in the world'
+        @type = 'website'
         @domain = 'awesome.org'
         @url = "https://#{@domain}/about"
         @image = "https://#{@domain}/images/favicon.ico"
@@ -627,7 +632,7 @@ EOS
       describe 'custom template for OpenGraphProperties' do
         before do
           allow(@tag).to receive(:get_properties).and_return(
-            Jekyll::Linkpreview::OpenGraphProperties.new @title, @url, @image, @description, @domain
+            Jekyll::Linkpreview::OpenGraphProperties.new @title, @type, @url, @image, @description, @domain
           )
         end
 
@@ -748,6 +753,7 @@ EOS
 
         got = @tag.get_properties(@url).to_hash
         expect(got['title']).to eq @title
+        expect(got['type']).to eq @type
         expect(got['url']).to eq @url
         expect(got['domain']).to eq @domain
         expect(got['image']).to eq @image
@@ -755,6 +761,7 @@ EOS
 
         got = @tag.get_properties(@url).to_hash
         expect(got['title']).to eq @title
+        expect(got['type']).to eq @type
         expect(got['url']).to eq @url
         expect(got['domain']).to eq @domain
         expect(got['image']).to eq @image

--- a/spec/jekyll-linkpreview_spec.rb
+++ b/spec/jekyll-linkpreview_spec.rb
@@ -708,6 +708,7 @@ EOS
   describe '#get_properties' do
     before do
       @title = 'awesome.org - an awesome organization in the world'
+      @type = 'website'
       @domain = 'awesome.org'
       @url = "https://#{@domain}/about"
       @image = "https://#{@domain}/images/favicon.ico"
@@ -726,6 +727,7 @@ EOS
 <html>
   <head>
     <meta property="og:title" content="#{@title}" />
+    <meta property="og:type" content="#{@type}" />
     <meta property="og:url" content="#{@url}" />
     <meta property="og:image" content="#{@image}" />
     <meta property="og:description" content="#{@description}" />


### PR DESCRIPTION
Closes #37.

This patch modifies the behavior of `create_properties_from_page` so that if the page lacks any of the required OGP tags, it will use a Non-OGP template. This patch prevents users from getting a blank link preview when all the previewed page's meta tags are unrelated to OGP.


Disregard the part below, I found a way to test this patch :)
~~There are currently no tests because I'm struggling to develop a way to test this behavior. Scraping is mocked away in the existing test suits, so adding a test for this patch to any of the existing test suits did not make much sense. `get_properties` includes fetching the page and extracting the properties, but should we split this method up just so that we can test this patch?~~