### PR TITLE
Fix broken CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,6 +31,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      - if: matrix.ruby == '2.7'
+        name: Update RubyGems version
+        # sass-embedded 1.57.1, which is one of dependencies of jekyll-sass-converter 3.0,
+        # requires rubygems version >= 3.3.22
+        # (see https://jekyllrb.com/news/2022/12/21/jekyll-sass-converter-3.0-released/
+        #  for the jekyll-sass-converter 3.0 release).
+        # Just running `gem update --system` upgrades rubygems version to '>= 2.4',
+        # which appraisal 2.4.1 can't work with.
+        run: gem update --system 3.3.22
       - name: Install dependencies
         run: bundle install
       - name: Install dependencies for each appraisal

--- a/jekyll-linkpreview.gemspec
+++ b/jekyll-linkpreview.gemspec
@@ -20,10 +20,12 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "jekyll", ">= 3.5", "< 5.0"
   spec.add_dependency "metainspector", "~> 5.9"
-  spec.add_development_dependency "bundler", "~> 2.0"
+  # appraisal 2.4.1, which is the latest version as of Jan 2023, doesn't work with bundler >= 2.4.
+  # See https://github.com/thoughtbot/appraisal/issues/199 for details.
+  spec.add_development_dependency "bundler", ">= 2.0", "< 2.4"
   spec.add_development_dependency "rake", "~> 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec-parameterized", "~> 0.5.2"
-  spec.add_development_dependency "appraisal", "~> 2.2.0"
+  spec.add_development_dependency "appraisal", "~> 2.0"
   spec.add_development_dependency "wwtd", "~> 1.4.1"
 end


### PR DESCRIPTION
But this is just a hot fix and it'll break again when the new version of sass-embedded is released, which depends on the newer version of rubygems. If the new version starts to depend on rubygems >= 3.4 which comes with bundler 2.4, this would be a problem as appraisal can't work with bundler 2.4.

There are several alternative solutions:

- Use jekyll-sass-converter < 3.0. But this is not ideal as we can't keep up with its new versions.
- Remove appraisal from dependencies of this plugin. As the latest 2.4.1 was released in July 2021, I don't think it's sufficiently maintained. I'd need to look for other libraries to enable testing with several versions of Jekyll. But testing with the latest Jekyll might be sufficient.