### PR TITLE
Make pull_request and push events exclusive

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,5 +1,11 @@
 name: Test
-on: [pull_request, push]
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
 jobs:
   test:
     container:


### PR DESCRIPTION
As test workflow ran for both `pull_request` and `push` events on #43, this PR is making them exclusive.