### PR TITLE
Delete link before preview

### DIFF
--- a/lib/jekyll-linkpreview.rb
+++ b/lib/jekyll-linkpreview.rb
@@ -244,11 +244,11 @@ module Jekyll
         image_html = ""
         if image then
           image_html = <<-EOS
-<div class="jekyll-linkpreview-image">
-  <a href="#{url}" target="_blank">
-    <img src="#{image}" />
-  </a>
-</div>
+      <div class="jekyll-linkpreview-image">
+        <a href="#{url}" target="_blank">
+          <img src="#{image}" />
+        </a>
+      </div>
 EOS
         end
         html = <<-EOS

--- a/lib/jekyll-linkpreview.rb
+++ b/lib/jekyll-linkpreview.rb
@@ -253,7 +253,6 @@ EOS
         end
         html = <<-EOS
 <div class="jekyll-linkpreview-wrapper">
-  <p><a href="#{url}" target="_blank">#{url}</a></p>
   <div class="jekyll-linkpreview-wrapper-inner">
     <div class="jekyll-linkpreview-content">
 #{image_html}


### PR DESCRIPTION
closes #45 
refs #30 

As several users have requested deleting/disabling a link showing up before preview, this PR is deleting the link.