### PR TITLE
Make the plugin work with Ruby 3.2

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,6 +37,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      # See https://github.com/actions/runner-images/issues/6775.
+      - name: Suppress 'detected dubious ownership' error
+        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
       - if: matrix.ruby == '2.7'
         name: Update RubyGems version
         # sass-embedded 1.57.1, which is one of dependencies of jekyll-sass-converter 3.0,

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ["2.7", "3.1"]
+        ruby: ["2.7", "3.1", "3.2"]
         appraisal:
           - jekyll-35
           - jekyll-36

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,6 +34,14 @@ jobs:
             appraisal: jekyll-37
           - ruby: "3.1"
             appraisal: jekyll-38
+          - ruby: "3.2"
+            appraisal: jekyll-35
+          - ruby: "3.2"
+            appraisal: jekyll-36
+          - ruby: "3.2"
+            appraisal: jekyll-37
+          - ruby: "3.2"
+            appraisal: jekyll-38
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,12 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in jekyll-linkpreview.gemspec
 gemspec
+
+# The issue that appraisal 2.4.1 can't work with bundler >= 2.4 was solved
+# (see https://github.com/thoughtbot/appraisal/issues/199 for details),
+# but a new version has not been released yet as of Apr 2023.
+# As it's not possible to install a gem from a git repository in the gemspec file,
+# appraisal is being installed in Gemfile.
+group :development do
+  gem 'appraisal', git: 'https://github.com/thoughtbot/appraisal'
+end

--- a/jekyll-linkpreview.gemspec
+++ b/jekyll-linkpreview.gemspec
@@ -20,12 +20,9 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "jekyll", ">= 3.5", "< 5.0"
   spec.add_dependency "metainspector", "~> 5.9"
-  # appraisal 2.4.1, which is the latest version as of Jan 2023, doesn't work with bundler >= 2.4.
-  # See https://github.com/thoughtbot/appraisal/issues/199 for details.
-  spec.add_development_dependency "bundler", ">= 2.0", "< 2.4"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec-parameterized", "~> 0.5.2"
-  spec.add_development_dependency "appraisal", "~> 2.0"
   spec.add_development_dependency "wwtd", "~> 1.4.1"
 end

--- a/lib/jekyll-linkpreview.rb
+++ b/lib/jekyll-linkpreview.rb
@@ -161,7 +161,7 @@ module Jekyll
         end
         page = fetch(url)
         properties = create_properties_from_page(page)
-        if Dir.exists?(@@cache_dir) then
+        if Dir.exist?(@@cache_dir) then
           save_cache_file(cache_filepath, properties)
         else
           # TODO: This message will be shown at all linkprevew tag


### PR DESCRIPTION
fixes #48

Replaced `Dir.exists?` with `Dir.exist?` and made the `test` workflow run with Ruby 3.2 to make sure the plugin works with the version.