### PR TITLE
Add more og properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,29 +49,53 @@ You can override the default templates used for generating previews, both in cas
 
 ### Template for pages where Open Graph protocol metadata exists
 
- 1. Place `linkpreview.html` file inside `_includes/` folder of your Jekyll site (`_includes/linkpreview.html`)
+1. Place `linkpreview.html` file inside `_includes/` folder of your Jekyll site (`_includes/linkpreview.html`)
      * The folder is the same one you would store files for use with `{% include fragment.html %}` tag. 
        Therefore, it *must* be under the [site's source](https://jekyllrb.com/docs/configuration/options/).
 
- 2. Use built-in variables to extract data which you would like to render. Available variables are:
-  * **link_url** i.e. `{{ link_url }}`
-  * **link_title** i.e. `{{ link_title }}`
-  * **link_type** i.e. `{{ link_type }}`
-  * **link_image** i.e. `{{ link_image }}`
-  * **link_description** i.e. `{{ link_description }}`
-  * **link_domain** i.e. `{{ link_domain }}`
+2. Use built-in variables to extract data which you would like to render. Available variables are:
+    * basic metadata
+        * `{{ link_title }}` for `og:title`
+        * `{{ link_type }}` for `og:type`
+        * `{{ link_image }}` for `og:image`
+        * `{{ link_url }}` for `og:url`
+    * optional metadata
+        * `{{ link_description }}` for `og:description`
+        * `{{ link_determiner }}` for `og:determiner`
+        * `{{ link_locale }}` for `og:locale`
+        * `{{ link_locale_alternate }}` for `og:locale:alternate`
+        * `{{ link_site_name }}` for `og:site_name`
+        * image
+            * `{{ link_image }}` for `og:image`
+            * `{{ link_image_secure_url }}` for `og:image:secure_url`
+            * `{{ link_image_type }}` for `og:image:type`
+            * `{{ link_image_width }}` for `og:image:width`
+            * `{{ link_image_height }}` for `og:image:height`
+            * `{{ link_image_alt }}` for `og:image:alt`
+        * video
+            * `{{ link_video }}` for `og:video`
+            * `{{ link_video_secure_url }}` for `og:video:secure_url`
+            * `{{ link_video_type }}` for `og:video:type`
+            * `{{ link_video_width }}` for `og:video:width`
+            * `{{ link_video_height }}` for `og:video:height`
+        * audio
+            * `{{ link_audio }}` for `og:audio`
+            * `{{ link_audio_secure_url }}` for `og:audio:secure_url`
+            * `{{ link_audio_type }}` for `og:audio:type`
+    * non og metadata
+        * `{{ link_domain }}`
 
 ### Template for pages where Open Graph protocol metadata does not exist
 
 1. Place `linkpreview_nog.html` file inside `_includes/` folder of your Jekyll site (`_includes/linkpreview_nog.html`)
-   * The folder is the same one you would store files for use with `{% include fragment.html %}` tag.
-     Therefore, it *must* be under the [site's source](https://jekyllrb.com/docs/configuration/options/).
+    * The folder is the same one you would store files for use with `{% include fragment.html %}` tag.
+      Therefore, it *must* be under the [site's source](https://jekyllrb.com/docs/configuration/options/).
 
- 2. Use built-in variables to extract data which you would like to render. Available variables are:
-  * **link_url** i.e. `{{ link_url }}`
-  * **link_title** i.e. `{{ link_title }}`
-  * **link_description** i.e. `{{ link_description }}`
-  * **link_domain** i.e. `{{ link_domain }}`
+2. Use built-in variables to extract data which you would like to render. Available variables are:
+    * `{{ link_title }}`
+    * `{{ link_url }}`
+    * `{{ link_description }}`
+    * `{{ link_domain }}`
 
 ## Development
 

--- a/lib/jekyll-linkpreview.rb
+++ b/lib/jekyll-linkpreview.rb
@@ -40,11 +40,35 @@ module Jekyll
       def from_page(page)
         properties = page.meta_tags['property']
         og_properties = {
+          # basic metadata (https://ogp.me/#metadata)
           'title' => get_property(properties, 'og:title'),
           'type' => get_property(properties, 'og:type'),
           'url' => get_property(properties, 'og:url'),
           'image' => convert_to_absolute_url(get_property(properties, 'og:image'), page.root_url),
+          # optional metadata (https://ogp.me/#optional)
+          ## image
+          'image_secure_url' => convert_to_absolute_url(get_property(properties, 'og:image:secure_url'), page.root_url),
+          'image_type' => get_property(properties, 'og:image:type'),
+          'image_width' => get_property(properties, 'og:image:width'),
+          'image_height' => get_property(properties, 'og:image:height'),
+          'image_alt' => get_property(properties, 'og:image:alt'),
+          ## video
+          'video' => convert_to_absolute_url(get_property(properties, 'og:video'), page.root_url),
+          'video_secure_url' => convert_to_absolute_url(get_property(properties, 'og:video:secure_url'), page.root_url),
+          'video_type' => get_property(properties, 'og:video:type'),
+          'video_width' => get_property(properties, 'og:video:width'),
+          'video_height' => get_property(properties, 'og:video:height'),
+          ## audio
+          'audio' => convert_to_absolute_url(get_property(properties, 'og:audio'), page.root_url),
+          'audio_secure_url' => convert_to_absolute_url(get_property(properties, 'og:audio:secure_url'), page.root_url),
+          'audio_type' => get_property(properties, 'og:audio:type'),
+          ## other optional metadata
           'description' => get_property(properties, 'og:description'),
+          'determiner' => get_property(properties, 'og:determiner'),
+          'locale' => get_property(properties, 'og:locale'),
+          'locale_alternate' => get_property(properties, 'og:locale:alternate'),
+          'site_name' => get_property(properties, 'og:site_name'),
+          # not defined in OGP
           'domain' => page.host,
         }
         Properties.new(og_properties, @@template_file)

--- a/lib/jekyll-linkpreview.rb
+++ b/lib/jekyll-linkpreview.rb
@@ -7,11 +7,10 @@ require "jekyll-linkpreview/version"
 
 module Jekyll
   module Linkpreview
-    class OpenGraphProperties
-      @@template_file = 'linkpreview.html'
-
-      def initialize(properties)
+    class Properties
+      def initialize(properties, template_file)
         @properties = properties
+        @template_file = template_file
       end
 
       def to_hash()
@@ -27,11 +26,17 @@ module Jekyll
       end
 
       def template_file()
-        @@template_file
+        @template_file
       end
     end
 
     class OpenGraphPropertiesFactory
+      @@template_file = 'linkpreview.html'
+
+      def self.template_file
+        @@template_file
+      end
+
       def from_page(page)
         properties = page.meta_tags['property']
         og_properties = {
@@ -42,11 +47,11 @@ module Jekyll
           'description' => get_property(properties, 'og:description'),
           'domain' => page.host,
         }
-        OpenGraphProperties.new(og_properties)
+        Properties.new(og_properties, @@template_file)
       end
 
       def from_hash(hash)
-        OpenGraphProperties.new(hash)
+        Properties.new(hash, @@template_file)
       end
 
       private
@@ -70,42 +75,24 @@ module Jekyll
       end
     end
 
-    class NonOpenGraphProperties
+    class NonOpenGraphPropertiesFactory
       @@template_file = 'linkpreview_nog.html'
 
-      def initialize(properties)
-        @properties = properties
-      end
-
-      def to_hash()
-        @properties
-      end
-
-      def to_hash_for_custom_template()
-        hash_for_custom_template = {}
-        @properties.each{ |key, value|
-          hash_for_custom_template['link_' + key] = value
-        }
-        hash_for_custom_template
-      end
-
-      def template_file()
+      def self.template_file
         @@template_file
       end
-    end
 
-    class NonOpenGraphPropertiesFactory
       def from_page(page)
-        NonOpenGraphProperties.new({
+        Properties.new({
           'title' => page.best_title,
           'url' => page.url,
           'description' => get_description(page),
           'domain' => page.host,
-        })
+        }, @@template_file)
       end
 
       def from_hash(hash)
-        NonOpenGraphProperties.new(hash)
+        Properties.new(hash, @@template_file)
       end
 
       private

--- a/spec/jekyll-linkpreview_spec.rb
+++ b/spec/jekyll-linkpreview_spec.rb
@@ -149,6 +149,18 @@ RSpec.describe 'Jekyll::Linkpreview::OpenGraphPropertiesFactory' do
           end
         end
       end
+
+      describe 'og:type' do
+        before do
+          @type = 'website'
+          @page = MetaInspector.new(url, :document => _generate_html([["og:type", @type]]))
+        end
+
+        it "can extract 'og:type'" do
+          got = @factory.from_page(@page).to_hash
+          expect(got['type']).to eq @type
+        end
+      end
     end
 
     describe 'optional metadata' do

--- a/spec/jekyll-linkpreview_spec.rb
+++ b/spec/jekyll-linkpreview_spec.rb
@@ -703,17 +703,13 @@ EOS
         allow(@tag).to receive(:fetch).and_return(
           MetaInspector.new(
             @url,
-            :document => <<-EOS
-<html>
-  <head>
-    <meta property="og:title" content="#{@title}" />
-    <meta property="og:type" content="#{@type}" />
-    <meta property="og:url" content="#{@url}" />
-    <meta property="og:image" content="#{@image}" />
-    <meta property="og:description" content="#{@description}" />
-  </head>
-</html>
-EOS
+            :document => _generate_html([
+              ["og:title", @title],
+              ["og:type", @type],
+              ["og:url", @url],
+              ["og:image", @image],
+              ["og:description", @description],
+            ])
           )
         )
         Dir.mkdir @tag.cache_dir
@@ -749,16 +745,12 @@ EOS
         allow(@tag).to receive(:fetch).and_return(
           MetaInspector.new(
             @url,
-            :document => <<-EOS
-<html>
-  <head>
-    <meta property="og:title" content="#{@title}" />
-    <meta property="og:type" content="#{@type}" />
-    <meta property="og:url" content="#{@url}" />
-    <meta property="og:image" content="#{@image}" />
-  </head>
-</html>
-EOS
+            :document => _generate_html([
+              ["og:title", @title],
+              ["og:type", @type],
+              ["og:url", @url],
+              ["og:image", @image],
+            ])
           )
         )
         Dir.mkdir @tag.cache_dir
@@ -779,18 +771,7 @@ EOS
     context 'when the page is missing required OGP tags' do
       before do
         allow(@tag).to receive(:fetch).and_return(
-          MetaInspector.new(
-            @url,
-            :document => <<-EOS
-<html>
-  <head>
-    <meta property="something" content="unrelated" />
-    <meta property="is" content="here" />
-    <meta property="og:title" content="is set but other required tags are missing" />
-  </head>
-</html>
-EOS
-          )
+          MetaInspector.new(@url, :document => _generate_html([["og:title", @title]]))
         )
         Dir.mkdir @tag.cache_dir
       end

--- a/spec/jekyll-linkpreview_spec.rb
+++ b/spec/jekyll-linkpreview_spec.rb
@@ -348,76 +348,11 @@ RSpec.describe 'Jekyll::Linkpreview::OpenGraphPropertiesFactory' do
         end
       end
 
-      describe 'description' do
-        context "when 'og:description' tag has a content" do
-          before do
-            url = 'https://awesome.org/about'
-            @description = 'An awesome organization in the world.'
-            @page = MetaInspector.new(
-              url,
-              :document => <<-EOS
-<html>
-  <head>
-    <meta property="og:description" content="#{@description}" />
-  </head>
-</html>
-EOS
-            )
-          end
-
-          it 'can extract description' do
-            got = @factory.from_page(@page).to_hash
-            expect(got['description']).to eq @description
-          end
-        end
-
-        context "when 'og:description' tag has an empty content" do
-          before do
-            url = 'https://awesome.org/about'
-            @page = MetaInspector.new(
-              url,
-              :document => <<-EOS
-<html>
-  <head>
-    <meta property="og:description" content="" />
-  </head>
-</html>
-EOS
-            )
-          end
-
-          it 'cannot extract description' do
-            got = @factory.from_page(@page).to_hash
-            expect(got['description']).to eq ''
-          end
-        end
-
-        context "when 'og:description' tag does not exist" do
-          before do
-            url = 'https://awesome.org/about'
-            @page = MetaInspector.new(
-              url,
-              :document => <<-EOS
-<html>
-  <head>
-    <meta property="og:title" content="" />
-  </head>
-</html>
-EOS
-            )
-          end
-
-          it 'cannot extract description' do
-            got = @factory.from_page(@page).to_hash
-            expect(got['description']).to eq nil
-          end
-        end
-      end
-
       describe 'other optional metadata' do
         context "when other optional metadata tags have a content" do
           before do
             url = 'https://awesome.org/about'
+            @description = 'An awesome organization in the world.'
             @determiner = 'the'
             @locale = 'en_GB'
             @locale_alternate = ['fr_FR', 'es_ES']
@@ -425,6 +360,7 @@ EOS
             @page = MetaInspector.new(
               url,
               :document => _generate_html([
+                ["og:description", @description],
                 ["og:determiner", @determiner],
                 ["og:locale", @locale],
                 ["og:locale:alternate", @locale_alternate[0]],
@@ -436,6 +372,7 @@ EOS
 
           it 'can extract metadata' do
             got = @factory.from_page(@page).to_hash
+            expect(got['description']).to eq @description
             expect(got['determiner']).to eq @determiner
             expect(got['locale']).to eq @locale
             # TODO: All values must be extracted.

--- a/spec/jekyll-linkpreview_spec.rb
+++ b/spec/jekyll-linkpreview_spec.rb
@@ -130,92 +130,22 @@ RSpec.describe 'Jekyll::Linkpreview::OpenGraphPropertiesFactory' do
         end
       end
 
-      describe 'image' do
-        context "when the content of 'og:image' tag is an absolute url" do
-          before do
-            root_url = 'https://awesome.org/'
-            url = URI.join(root_url, 'about').to_s
-            @image_url = URI.join(root_url, 'images/favicon.ico').to_s
-            @page = MetaInspector.new(
-              url,
-              :document => <<-EOS
-<html>
-  <head>
-    <meta property="og:image" content="#{@image_url}" />
-  </head>
-</html>
-EOS
-            )
-          end
-
-          it 'can extract image url' do
-            got = @factory.from_page(@page).to_hash
-            expect(got['image']).to eq @image_url
-          end
+      describe 'og:image' do
+        where(:image, :expected) do
+          [
+            ["https://#{domain}/ogp.jpg", "https://#{domain}/ogp.jpg"],  # absolute url
+            ['/ogp.jpg', "https://#{domain}/ogp.jpg"],  # root-relative url
+          ]
         end
 
-        context "when the content of 'og:image' tag is a root-relative url" do
+        with_them do
           before do
-            @root_url = 'https://awesome.org/'
-            url = URI.join(@root_url, 'about').to_s
-            @image_url = '/images/favicon.ico'
-            @page = MetaInspector.new(
-              url,
-              :document => <<-EOS
-<html>
-  <head>
-    <meta property="og:image" content="#{@image_url}" />
-  </head>
-</html>
-EOS
-            )
+            @page = MetaInspector.new(url, :document => _generate_html([["og:image", image]]))
           end
 
-          it 'can convert a root-relative image url to an absolute one' do
+          it "can extract 'og:image'" do
             got = @factory.from_page(@page).to_hash
-            expect(got['image']).to eq URI.join(@root_url, @image_url).to_s
-          end
-        end
-
-        context "when 'og:image' tag has an empty content" do
-          before do
-            url = 'https://awesome.org/about'
-            @page = MetaInspector.new(
-              url,
-              :document => <<-EOS
-<html>
-  <head>
-    <meta property="og:image" content="" />
-  </head>
-</html>
-EOS
-            )
-          end
-
-          it 'cannot extract image url' do
-            got = @factory.from_page(@page).to_hash
-            expect(got['image']).to eq ''
-          end
-        end
-
-        context "when 'og:image' tag does not exist" do
-          before do
-            url = 'https://awesome.org/about'
-            @page = MetaInspector.new(
-              url,
-              :document => <<-EOS
-<html>
-  <head>
-    <meta property="og:title" content="" />
-  </head>
-</html>
-EOS
-            )
-          end
-
-          it 'cannot extract image url' do
-            got = @factory.from_page(@page).to_hash
-            expect(got['image']).to eq nil
+            expect(got['image']).to eq expected
           end
         end
       end

--- a/spec/jekyll-linkpreview_spec.rb
+++ b/spec/jekyll-linkpreview_spec.rb
@@ -95,69 +95,15 @@ RSpec.describe 'Jekyll::Linkpreview::OpenGraphPropertiesFactory' do
     let(:url) { "https://#{domain}/about" }
 
     describe 'basic metadata' do
-      describe 'title' do
-        context "when 'og:title' tag has a content" do
-          before do
-            @title = 'awesome.org - an awesome organization in the world'
-            url = 'https://awesome.org/about'
-            @page = MetaInspector.new(
-              url,
-              :document => <<-EOS
-<html>
-  <head>
-    <meta property="og:title" content="#{@title}" />
-  </head>
-</html>
-EOS
-            )
-          end
-
-          it 'can extract title' do
-            got = @factory.from_page(@page).to_hash
-            expect(got['title']).to eq @title
-          end
+      describe 'og:title' do
+        before do
+          @title = 'awesome.org - an awesome organization in the world'
+          @page = MetaInspector.new(url, :document => _generate_html([["og:title", @title]]))
         end
 
-        context "when 'og:title' tag has an empty content" do
-          before do
-            url = 'https://awesome.org/about'
-            @page = MetaInspector.new(
-              url,
-              :document => <<-EOS
-<html>
-  <head>
-    <meta property="og:title" content="" />
-  </head>
-</html>
-EOS
-            )
-          end
-
-          it 'cannot extract title' do
-            got = @factory.from_page(@page).to_hash
-            expect(got['title']).to eq ''
-          end
-        end
-
-        context "when 'og:title' tag does not exist" do
-          before do
-            url = 'https://awesome.org/about'
-            @page = MetaInspector.new(
-              url,
-              :document => <<-EOS
-<html>
-  <head>
-    <meta property="og:url" content="#{url}" />
-  </head>
-</html>
-EOS
-            )
-          end
-
-          it 'cannot extract title' do
-            got = @factory.from_page(@page).to_hash
-            expect(got['title']).to eq nil
-          end
+        it "can extract 'og:title'" do
+          got = @factory.from_page(@page).to_hash
+          expect(got['title']).to eq @title
         end
       end
 

--- a/spec/jekyll-linkpreview_spec.rb
+++ b/spec/jekyll-linkpreview_spec.rb
@@ -90,340 +90,344 @@ RSpec.describe 'Jekyll::Linkpreview::OpenGraphPropertiesFactory' do
   end
 
   describe '#from_page' do
-    describe 'title' do
-      context "when 'og:title' tag has a content" do
-        before do
-          @title = 'awesome.org - an awesome organization in the world'
-          url = 'https://awesome.org/about'
-          @page = MetaInspector.new(
-            url,
-            :document => <<-EOS
+    describe 'basic metadata' do
+      describe 'title' do
+        context "when 'og:title' tag has a content" do
+          before do
+            @title = 'awesome.org - an awesome organization in the world'
+            url = 'https://awesome.org/about'
+            @page = MetaInspector.new(
+              url,
+              :document => <<-EOS
 <html>
   <head>
     <meta property="og:title" content="#{@title}" />
   </head>
 </html>
 EOS
-          )
+            )
+          end
+
+          it 'can extract title' do
+            got = @factory.from_page(@page).to_hash
+            expect(got['title']).to eq @title
+          end
         end
 
-        it 'can extract title' do
-          got = @factory.from_page(@page).to_hash
-          expect(got['title']).to eq @title
-        end
-      end
-
-      context "when 'og:title' tag has an empty content" do
-        before do
-          url = 'https://awesome.org/about'
-          @page = MetaInspector.new(
-            url,
-            :document => <<-EOS
+        context "when 'og:title' tag has an empty content" do
+          before do
+            url = 'https://awesome.org/about'
+            @page = MetaInspector.new(
+              url,
+              :document => <<-EOS
 <html>
   <head>
     <meta property="og:title" content="" />
   </head>
 </html>
 EOS
-          )
+            )
+          end
+
+          it 'cannot extract title' do
+            got = @factory.from_page(@page).to_hash
+            expect(got['title']).to eq ''
+          end
         end
 
-        it 'cannot extract title' do
-          got = @factory.from_page(@page).to_hash
-          expect(got['title']).to eq ''
-        end
-      end
-
-      context "when 'og:title' tag does not exist" do
-        before do
-          url = 'https://awesome.org/about'
-          @page = MetaInspector.new(
-            url,
-            :document => <<-EOS
+        context "when 'og:title' tag does not exist" do
+          before do
+            url = 'https://awesome.org/about'
+            @page = MetaInspector.new(
+              url,
+              :document => <<-EOS
 <html>
   <head>
     <meta property="og:url" content="#{url}" />
   </head>
 </html>
 EOS
-          )
-        end
+            )
+          end
 
-        it 'cannot extract title' do
-          got = @factory.from_page(@page).to_hash
-          expect(got['title']).to eq nil
+          it 'cannot extract title' do
+            got = @factory.from_page(@page).to_hash
+            expect(got['title']).to eq nil
+          end
         end
       end
-    end
 
-    describe 'url and domain' do
-      context "when 'og:url' tag is https" do
-        before do
-          @domain = 'awesome.org'
-          @url = "https://#{@domain}/about"
-          @page = MetaInspector.new(
-            @url,
-            :document => <<-EOS
+      describe 'url and domain' do
+        context "when 'og:url' tag is https" do
+          before do
+            @domain = 'awesome.org'
+            @url = "https://#{@domain}/about"
+            @page = MetaInspector.new(
+              @url,
+              :document => <<-EOS
 <html>
   <head>
     <meta property="og:url" content="#{@url}" />
   </head>
 </html>
 EOS
-          )
+            )
+          end
+
+          it 'can extract url and domain' do
+            got = @factory.from_page(@page).to_hash
+            expect(got['url']).to eq @url
+            expect(got['domain']).to eq @domain
+          end
         end
 
-        it 'can extract url and domain' do
-          got = @factory.from_page(@page).to_hash
-          expect(got['url']).to eq @url
-          expect(got['domain']).to eq @domain
-        end
-      end
-
-      context "when 'og:url' tag is http" do
-        before do
-          @domain = 'awesome.org'
-          @url = "https://#{@domain}/about"
-          @page = MetaInspector.new(
-            @url,
-            :document => <<-EOS
+        context "when 'og:url' tag is http" do
+          before do
+            @domain = 'awesome.org'
+            @url = "https://#{@domain}/about"
+            @page = MetaInspector.new(
+              @url,
+              :document => <<-EOS
 <html>
   <head>
     <meta property="og:url" content="#{@url}" />
   </head>
 </html>
 EOS
-          )
+            )
+          end
+
+          it 'can extract url and domain' do
+            got = @factory.from_page(@page).to_hash
+            expect(got['url']).to eq @url
+            expect(got['domain']).to eq @domain
+          end
         end
 
-        it 'can extract url and domain' do
-          got = @factory.from_page(@page).to_hash
-          expect(got['url']).to eq @url
-          expect(got['domain']).to eq @domain
-        end
-      end
-
-      context "when 'og:url' tag has ill-formed URL" do
-        before do
-          @domain = 'awesome.org'
-          url = "https://#{@domain}/about"
-          @page = MetaInspector.new(
-            url,
-            :document => <<-EOS
+        context "when 'og:url' tag has ill-formed URL" do
+          before do
+            @domain = 'awesome.org'
+            url = "https://#{@domain}/about"
+            @page = MetaInspector.new(
+              url,
+              :document => <<-EOS
 <html>
   <head>
     <meta property="og:url" content="ill-formed" />
   </head>
 </html>
 EOS
-          )
+            )
+          end
+
+          it 'can extract url and domain' do
+            got = @factory.from_page(@page).to_hash
+            expect(got['url']).to eq 'ill-formed'
+            expect(got['domain']).to eq @domain
+          end
         end
 
-        it 'can extract url and domain' do
-          got = @factory.from_page(@page).to_hash
-          expect(got['url']).to eq 'ill-formed'
-          expect(got['domain']).to eq @domain
-        end
-      end
-
-      context "when 'og:url' tag has an empty content" do
-        before do
-          @domain = 'awesome.org'
-          url = "https://#{@domain}/about"
-          @page = MetaInspector.new(
-            url,
-            :document => <<-EOS
+        context "when 'og:url' tag has an empty content" do
+          before do
+            @domain = 'awesome.org'
+            url = "https://#{@domain}/about"
+            @page = MetaInspector.new(
+              url,
+              :document => <<-EOS
 <html>
   <head>
     <meta property="og:url" content="" />
   </head>
 </html>
 EOS
-          )
+            )
+          end
+
+          it 'cannot extract url but can extract domain' do
+            got = @factory.from_page(@page).to_hash
+            expect(got['url']).to eq ''
+            expect(got['domain']).to eq @domain
+          end
         end
 
-        it 'cannot extract url but can extract domain' do
-          got = @factory.from_page(@page).to_hash
-          expect(got['url']).to eq ''
-          expect(got['domain']).to eq @domain
-        end
-      end
-
-      context "when 'og:url' tag does not exist" do
-        before do
-          url = 'https://awesome.org/about'
-          @page = MetaInspector.new(
-            url,
-            :document => <<-EOS
+        context "when 'og:url' tag does not exist" do
+          before do
+            url = 'https://awesome.org/about'
+            @page = MetaInspector.new(
+              url,
+              :document => <<-EOS
 <html>
   <head>
     <meta property="og:title" content="" />
   </head>
 </html>
 EOS
-          )
-        end
+            )
+          end
 
-        it 'cannot extract url but can extract domain' do
-          got = @factory.from_page(@page).to_hash
-          expect(got['url']).to eq nil
-          expect(got['domain']).to eq 'awesome.org'
+          it 'cannot extract url but can extract domain' do
+            got = @factory.from_page(@page).to_hash
+            expect(got['url']).to eq nil
+            expect(got['domain']).to eq 'awesome.org'
+          end
         end
       end
-    end
 
-    describe 'image' do
-      context "when the content of 'og:image' tag is an absolute url" do
-        before do
-          root_url = 'https://awesome.org/'
-          url = URI.join(root_url, 'about').to_s
-          @image_url = URI.join(root_url, 'images/favicon.ico').to_s
-          @page = MetaInspector.new(
-            url,
-            :document => <<-EOS
+      describe 'image' do
+        context "when the content of 'og:image' tag is an absolute url" do
+          before do
+            root_url = 'https://awesome.org/'
+            url = URI.join(root_url, 'about').to_s
+            @image_url = URI.join(root_url, 'images/favicon.ico').to_s
+            @page = MetaInspector.new(
+              url,
+              :document => <<-EOS
 <html>
   <head>
     <meta property="og:image" content="#{@image_url}" />
   </head>
 </html>
 EOS
-          )
+            )
+          end
+
+          it 'can extract image url' do
+            got = @factory.from_page(@page).to_hash
+            expect(got['image']).to eq @image_url
+          end
         end
 
-        it 'can extract image url' do
-          got = @factory.from_page(@page).to_hash
-          expect(got['image']).to eq @image_url
-        end
-      end
-
-      context "when the content of 'og:image' tag is a root-relative url" do
-        before do
-          @root_url = 'https://awesome.org/'
-          url = URI.join(@root_url, 'about').to_s
-          @image_url = '/images/favicon.ico'
-          @page = MetaInspector.new(
-            url,
-            :document => <<-EOS
+        context "when the content of 'og:image' tag is a root-relative url" do
+          before do
+            @root_url = 'https://awesome.org/'
+            url = URI.join(@root_url, 'about').to_s
+            @image_url = '/images/favicon.ico'
+            @page = MetaInspector.new(
+              url,
+              :document => <<-EOS
 <html>
   <head>
     <meta property="og:image" content="#{@image_url}" />
   </head>
 </html>
 EOS
-          )
+            )
+          end
+
+          it 'can convert a root-relative image url to an absolute one' do
+            got = @factory.from_page(@page).to_hash
+            expect(got['image']).to eq URI.join(@root_url, @image_url).to_s
+          end
         end
 
-        it 'can convert a root-relative image url to an absolute one' do
-          got = @factory.from_page(@page).to_hash
-          expect(got['image']).to eq URI.join(@root_url, @image_url).to_s
-        end
-      end
-
-      context "when 'og:image' tag has an empty content" do
-        before do
-          url = 'https://awesome.org/about'
-          @page = MetaInspector.new(
-            url,
-            :document => <<-EOS
+        context "when 'og:image' tag has an empty content" do
+          before do
+            url = 'https://awesome.org/about'
+            @page = MetaInspector.new(
+              url,
+              :document => <<-EOS
 <html>
   <head>
     <meta property="og:image" content="" />
   </head>
 </html>
 EOS
-          )
+            )
+          end
+
+          it 'cannot extract image url' do
+            got = @factory.from_page(@page).to_hash
+            expect(got['image']).to eq ''
+          end
         end
 
-        it 'cannot extract image url' do
-          got = @factory.from_page(@page).to_hash
-          expect(got['image']).to eq ''
-        end
-      end
-
-      context "when 'og:image' tag does not exist" do
-        before do
-          url = 'https://awesome.org/about'
-          @page = MetaInspector.new(
-            url,
-            :document => <<-EOS
+        context "when 'og:image' tag does not exist" do
+          before do
+            url = 'https://awesome.org/about'
+            @page = MetaInspector.new(
+              url,
+              :document => <<-EOS
 <html>
   <head>
     <meta property="og:title" content="" />
   </head>
 </html>
 EOS
-          )
-        end
+            )
+          end
 
-        it 'cannot extract image url' do
-          got = @factory.from_page(@page).to_hash
-          expect(got['image']).to eq nil
+          it 'cannot extract image url' do
+            got = @factory.from_page(@page).to_hash
+            expect(got['image']).to eq nil
+          end
         end
       end
     end
 
-    describe 'description' do
-      context "when 'og:description' tag has a content" do
-        before do
-          url = 'https://awesome.org/about'
-          @description = 'An awesome organization in the world.'
-          @page = MetaInspector.new(
-            url,
-            :document => <<-EOS
+    describe 'optional metadata' do
+      describe 'description' do
+        context "when 'og:description' tag has a content" do
+          before do
+            url = 'https://awesome.org/about'
+            @description = 'An awesome organization in the world.'
+            @page = MetaInspector.new(
+              url,
+              :document => <<-EOS
 <html>
   <head>
     <meta property="og:description" content="#{@description}" />
   </head>
 </html>
 EOS
-          )
+            )
+          end
+
+          it 'can extract description' do
+            got = @factory.from_page(@page).to_hash
+            expect(got['description']).to eq @description
+          end
         end
 
-        it 'can extract description' do
-          got = @factory.from_page(@page).to_hash
-          expect(got['description']).to eq @description
-        end
-      end
-
-      context "when 'og:description' tag has an empty content" do
-        before do
-          url = 'https://awesome.org/about'
-          @page = MetaInspector.new(
-            url,
-            :document => <<-EOS
+        context "when 'og:description' tag has an empty content" do
+          before do
+            url = 'https://awesome.org/about'
+            @page = MetaInspector.new(
+              url,
+              :document => <<-EOS
 <html>
   <head>
     <meta property="og:description" content="" />
   </head>
 </html>
 EOS
-          )
+            )
+          end
+
+          it 'cannot extract description' do
+            got = @factory.from_page(@page).to_hash
+            expect(got['description']).to eq ''
+          end
         end
 
-        it 'cannot extract description' do
-          got = @factory.from_page(@page).to_hash
-          expect(got['description']).to eq ''
-        end
-      end
-
-      context "when 'og:description' tag does not exist" do
-        before do
-          url = 'https://awesome.org/about'
-          @page = MetaInspector.new(
-            url,
-            :document => <<-EOS
+        context "when 'og:description' tag does not exist" do
+          before do
+            url = 'https://awesome.org/about'
+            @page = MetaInspector.new(
+              url,
+              :document => <<-EOS
 <html>
   <head>
     <meta property="og:title" content="" />
   </head>
 </html>
 EOS
-          )
-        end
+            )
+          end
 
-        it 'cannot extract description' do
-          got = @factory.from_page(@page).to_hash
-          expect(got['description']).to eq nil
+          it 'cannot extract description' do
+            got = @factory.from_page(@page).to_hash
+            expect(got['description']).to eq nil
+          end
         end
       end
     end

--- a/spec/jekyll-linkpreview_spec.rb
+++ b/spec/jekyll-linkpreview_spec.rb
@@ -41,7 +41,14 @@ RSpec.describe 'Jekyll::Linkpreview::OpenGraphProperties' do
     @image = 'https://awesome.org/images/favicon.ico'
     @description = 'An awesome organization in the world.'
     @domain = 'awesome.org'
-    @properties = Jekyll::Linkpreview::OpenGraphProperties.new @title, @type, @url, @image, @description, @domain
+    @properties = Jekyll::Linkpreview::OpenGraphProperties.new({
+      'title' => @title,
+      'type' => @type,
+      'url' => @url,
+      'image' => @image,
+      'description' => @description,
+      'domain' => @domain,
+    })
   end
 
   describe '#to_hash' do
@@ -75,7 +82,12 @@ RSpec.describe 'Jekyll::Linkpreview::NonOpenGraphProperties' do
     @url = 'https://awesome.org/about'
     @description = 'An awesome organization in the world.'
     @domain = 'awesome.org'
-    @properties = Jekyll::Linkpreview::NonOpenGraphProperties.new @title, @url, @description, @domain
+    @properties = Jekyll::Linkpreview::NonOpenGraphProperties.new({
+      'title' => @title,
+      'url' => @url,
+      'description' => @description,
+      'domain' => @domain,
+    })
   end
 
   describe '#to_hash' do
@@ -632,7 +644,14 @@ EOS
       describe 'custom template for OpenGraphProperties' do
         before do
           allow(@tag).to receive(:get_properties).and_return(
-            Jekyll::Linkpreview::OpenGraphProperties.new @title, @type, @url, @image, @description, @domain
+            Jekyll::Linkpreview::OpenGraphProperties.new({
+              'title' => @title,
+              'type' => @type,
+              'url' => @url,
+              'image' => @image,
+              'description' => @description,
+              'domain' => @domain,
+            })
           )
         end
 
@@ -672,7 +691,12 @@ EOS
       describe 'custom template for NonOpenGraphProperties' do
         before do
           allow(@tag).to receive(:get_properties).and_return(
-            Jekyll::Linkpreview::NonOpenGraphProperties.new @title, @url, @description, @domain
+            Jekyll::Linkpreview::NonOpenGraphProperties.new({
+              'title' => @title,
+              'url' => @url,
+              'description' => @description,
+              'domain' => @domain,
+            })
           )
         end
 

--- a/spec/jekyll-linkpreview_spec.rb
+++ b/spec/jekyll-linkpreview_spec.rb
@@ -161,6 +161,20 @@ RSpec.describe 'Jekyll::Linkpreview::OpenGraphPropertiesFactory' do
           expect(got['type']).to eq @type
         end
       end
+
+      describe 'no basic metadata' do
+        before do
+          @page = MetaInspector.new(url, :document => _generate_html([]))
+        end
+
+        it "cannot extract basic metadata" do
+          got = @factory.from_page(@page).to_hash
+          expect(got['title']).to eq nil
+          expect(got['type']).to eq nil
+          expect(got['url']).to eq nil
+          expect(got['image']).to eq nil
+        end
+      end
     end
 
     describe 'optional metadata' do

--- a/spec/jekyll-linkpreview_spec.rb
+++ b/spec/jekyll-linkpreview_spec.rb
@@ -599,7 +599,7 @@ RSpec.describe 'Jekyll::Linkpreview::LinkpreviewTag' do
   <p class="domain">{{ link_domain }}</p>
   <p class="image">{{ link_image }}</p>
   <p class="description">{{ link_description }}</p>
-</dic>
+</div>
 EOS
         }
       end
@@ -612,7 +612,7 @@ EOS
   <p class="url">{{ link_url }}</p>
   <p class="domain">{{ link_domain }}</p>
   <p class="description">{{ link_description }}</p>
-</dic>
+</div>
 EOS
         }
       end

--- a/spec/jekyll-linkpreview_spec.rb
+++ b/spec/jekyll-linkpreview_spec.rb
@@ -90,6 +90,10 @@ RSpec.describe 'Jekyll::Linkpreview::OpenGraphPropertiesFactory' do
   end
 
   describe '#from_page' do
+    let(:domain) { 'awesome.org' }
+    let(:secure_domain) { "secure.#{domain}" }
+    let(:url) { "https://#{domain}/about" }
+
     describe 'basic metadata' do
       describe 'title' do
         context "when 'og:title' tag has a content" do
@@ -365,6 +369,202 @@ EOS
     end
 
     describe 'optional metadata' do
+      describe 'og:image:secure_url' do
+        where(:image_secure_url, :expected) do
+          [
+            ["https://#{secure_domain}/ogp.jpg", "https://#{secure_domain}/ogp.jpg"],  # absolute url
+            ['/ogp.jpg', "https://#{domain}/ogp.jpg"],  # root-relative url
+          ]
+        end
+
+        with_them do
+          before do
+            @page = MetaInspector.new(url, :document => _generate_html([["og:image:secure_url", image_secure_url]]))
+          end
+
+          it "can extract 'og:image:secure_url" do
+            got = @factory.from_page(@page).to_hash
+            expect(got['image_secure_url']).to eq expected
+          end
+        end
+      end
+
+      describe 'og:image:type' do
+        before do
+          @image_type = 'image/jpeg'
+          @page = MetaInspector.new(url, :document => _generate_html([["og:image:type", @image_type]]))
+        end
+
+        it "can extract 'og:image:type'" do
+          got = @factory.from_page(@page).to_hash
+          expect(got['image_type']).to eq @image_type
+        end
+      end
+
+      describe 'og:image:width' do
+        before do
+          @image_width = '400'
+          @page = MetaInspector.new(url, :document => _generate_html([["og:image:width", @image_width]]))
+        end
+
+        it "can extract 'og:image:width'" do
+          got = @factory.from_page(@page).to_hash
+          expect(got['image_width']).to eq @image_width
+        end
+      end
+
+      describe 'og:image:height' do
+        before do
+          @image_height = '300'
+          @page = MetaInspector.new(url, :document => _generate_html([["og:image:height", @image_height]]))
+        end
+
+        it "can extract 'og:image:height'" do
+          got = @factory.from_page(@page).to_hash
+          expect(got['image_height']).to eq @image_height
+        end
+      end
+
+      describe 'og:image:alt' do
+        before do
+          @image_alt = 'A shiny red apple with a bite taken out'
+          @page = MetaInspector.new(url, :document => _generate_html([["og:image:alt", @image_alt]]))
+        end
+
+        it "can extract 'og:image:alt'" do
+          got = @factory.from_page(@page).to_hash
+          expect(got['image_alt']).to eq @image_alt
+        end
+      end
+
+      describe 'og:video' do
+        where(:video, :expected) do
+          [
+            ["https://#{domain}/movie.swf", "https://#{domain}/movie.swf"],  # absolute url
+            ['/movie.swf', "https://#{domain}/movie.swf"],  # root-relative url
+          ]
+        end
+
+        with_them do
+          before do
+            @page = MetaInspector.new(url, :document => _generate_html([["og:video", video]]))
+          end
+
+          it "can extract 'og:video'" do
+            got = @factory.from_page(@page).to_hash
+            expect(got['video']).to eq expected
+          end
+        end
+      end
+
+      describe 'og:video:secure_url' do
+        where(:video_secure_url, :expected) do
+          [
+            ["https://#{secure_domain}/movie.swf", "https://#{secure_domain}/movie.swf"],  # absolute url
+            ['/movie.swf', "https://#{domain}/movie.swf"],  # root-relative url
+          ]
+        end
+
+        with_them do
+          before do
+            @page = MetaInspector.new(url, :document => _generate_html([["og:video:secure_url", video_secure_url]]))
+          end
+
+          it "can extract 'og:video:secure_url'" do
+            got = @factory.from_page(@page).to_hash
+            expect(got['video_secure_url']).to eq expected
+          end
+        end
+      end
+
+      describe 'og:video:type' do
+        before do
+          @video_type = 'application/x-shockwave-flash'
+          @page = MetaInspector.new(url, :document => _generate_html([["og:video:type", @video_type]]))
+        end
+
+        it "can extract 'og:video:type'" do
+          got = @factory.from_page(@page).to_hash
+          expect(got['video_type']).to eq @video_type
+        end
+      end
+
+      describe 'og:video:width' do
+        before do
+          @video_width = '400'
+          @page = MetaInspector.new(url, :document => _generate_html([["og:video:width", @video_width]]))
+        end
+
+        it "can extract 'og:video:width'" do
+          got = @factory.from_page(@page).to_hash
+          expect(got['video_width']).to eq @video_width
+        end
+      end
+
+      describe 'og:video:height' do
+        before do
+          @video_height = '300'
+          @page = MetaInspector.new(url, :document => _generate_html([["og:video:height", @video_height]]))
+        end
+
+        it "can extract 'og:video:height'" do
+          got = @factory.from_page(@page).to_hash
+          expect(got['video_height']).to eq @video_height
+        end
+      end
+
+      describe 'og:audio' do
+        where(:audio, :expected) do
+          [
+            ["https://#{domain}/sound.mp3", "https://#{domain}/sound.mp3"],  # absolute url
+            ['/sound.mp3', "https://#{domain}/sound.mp3"],  # root-relative url
+          ]
+        end
+
+        with_them do
+          before do
+            @page = MetaInspector.new(url, :document => _generate_html([["og:audio", audio]]))
+          end
+
+          it "can extract 'og:audio'" do
+            got = @factory.from_page(@page).to_hash
+            expect(got['audio']).to eq expected
+          end
+        end
+      end
+
+      describe 'og:audio:secure_url' do
+        where(:audio_secure_url, :expected) do
+          [
+            ["https://#{secure_domain}/sound.mp3", "https://#{secure_domain}/sound.mp3"],  # absolute url
+            ['/sound.mp3', "https://#{domain}/sound.mp3"],  # root-relative url
+          ]
+        end
+
+        with_them do
+          before do
+            @page = MetaInspector.new(url, :document => _generate_html([["og:audio:secure_url", audio_secure_url]]))
+          end
+
+          it "can extract 'og:audio:secure_url'" do
+            got = @factory.from_page(@page).to_hash
+            expect(got['audio_secure_url']).to eq expected
+          end
+        end
+      end
+
+      describe 'og:audio:type' do
+        before do
+          @audio_type = 'audio/mpeg'
+          @page = MetaInspector.new(url, :document => _generate_html([["og:audio:type", @audio_type]]))
+        end
+
+        it "can extract 'og:audio:type'" do
+          got = @factory.from_page(@page).to_hash
+          expect(got['audio_type']).to eq @audio_type
+        end
+      end
+
       describe 'description' do
         context "when 'og:description' tag has a content" do
           before do
@@ -427,6 +627,37 @@ EOS
           it 'cannot extract description' do
             got = @factory.from_page(@page).to_hash
             expect(got['description']).to eq nil
+          end
+        end
+      end
+
+      describe 'other optional metadata' do
+        context "when other optional metadata tags have a content" do
+          before do
+            url = 'https://awesome.org/about'
+            @determiner = 'the'
+            @locale = 'en_GB'
+            @locale_alternate = ['fr_FR', 'es_ES']
+            @site_name = 'IMDb'
+            @page = MetaInspector.new(
+              url,
+              :document => _generate_html([
+                ["og:determiner", @determiner],
+                ["og:locale", @locale],
+                ["og:locale:alternate", @locale_alternate[0]],
+                ["og:locale:alternate", @locale_alternate[1]],
+                ["og:site_name", @site_name],
+              ])
+            )
+          end
+
+          it 'can extract metadata' do
+            got = @factory.from_page(@page).to_hash
+            expect(got['determiner']).to eq @determiner
+            expect(got['locale']).to eq @locale
+            # TODO: All values must be extracted.
+            expect(got['locale_alternate']).to eq @locale_alternate[0]
+            expect(got['site_name']).to eq @site_name
           end
         end
       end
@@ -877,4 +1108,12 @@ RSpec.describe "Integration test" do
       expect(got).not_to include('Liquid error: internal')
     end
   end
+end
+
+def _generate_html(properties)
+  meta_tags = []
+  properties.each do |property, content|
+    meta_tags << "<meta property=\"#{property}\" content=\"#{content}\" />"
+  end
+  "<html><head>" + meta_tags.join + "</head></html>"
 end

--- a/spec/jekyll-linkpreview_spec.rb
+++ b/spec/jekyll-linkpreview_spec.rb
@@ -107,118 +107,25 @@ RSpec.describe 'Jekyll::Linkpreview::OpenGraphPropertiesFactory' do
         end
       end
 
-      describe 'url and domain' do
-        context "when 'og:url' tag is https" do
-          before do
-            @domain = 'awesome.org'
-            @url = "https://#{@domain}/about"
-            @page = MetaInspector.new(
-              @url,
-              :document => <<-EOS
-<html>
-  <head>
-    <meta property="og:url" content="#{@url}" />
-  </head>
-</html>
-EOS
-            )
-          end
-
-          it 'can extract url and domain' do
-            got = @factory.from_page(@page).to_hash
-            expect(got['url']).to eq @url
-            expect(got['domain']).to eq @domain
-          end
+      describe 'og:url' do
+        where(:og_url) do
+          [
+            # Intentinally a domain different from 'awesome.org' is used
+            # to show the url is extracted from 'og:url'.
+            ['https://example.com/about'],  # https
+            ['http://example.com/about'],  # http
+            ['ill-formed'],  # ill-formed
+          ]
         end
 
-        context "when 'og:url' tag is http" do
+        with_them do
           before do
-            @domain = 'awesome.org'
-            @url = "https://#{@domain}/about"
-            @page = MetaInspector.new(
-              @url,
-              :document => <<-EOS
-<html>
-  <head>
-    <meta property="og:url" content="#{@url}" />
-  </head>
-</html>
-EOS
-            )
+            @page = MetaInspector.new(url, :document => _generate_html([["og:url", og_url]]))
           end
 
-          it 'can extract url and domain' do
+          it "can extract 'og:url'" do
             got = @factory.from_page(@page).to_hash
-            expect(got['url']).to eq @url
-            expect(got['domain']).to eq @domain
-          end
-        end
-
-        context "when 'og:url' tag has ill-formed URL" do
-          before do
-            @domain = 'awesome.org'
-            url = "https://#{@domain}/about"
-            @page = MetaInspector.new(
-              url,
-              :document => <<-EOS
-<html>
-  <head>
-    <meta property="og:url" content="ill-formed" />
-  </head>
-</html>
-EOS
-            )
-          end
-
-          it 'can extract url and domain' do
-            got = @factory.from_page(@page).to_hash
-            expect(got['url']).to eq 'ill-formed'
-            expect(got['domain']).to eq @domain
-          end
-        end
-
-        context "when 'og:url' tag has an empty content" do
-          before do
-            @domain = 'awesome.org'
-            url = "https://#{@domain}/about"
-            @page = MetaInspector.new(
-              url,
-              :document => <<-EOS
-<html>
-  <head>
-    <meta property="og:url" content="" />
-  </head>
-</html>
-EOS
-            )
-          end
-
-          it 'cannot extract url but can extract domain' do
-            got = @factory.from_page(@page).to_hash
-            expect(got['url']).to eq ''
-            expect(got['domain']).to eq @domain
-          end
-        end
-
-        context "when 'og:url' tag does not exist" do
-          before do
-            url = 'https://awesome.org/about'
-            @page = MetaInspector.new(
-              url,
-              :document => <<-EOS
-<html>
-  <head>
-    <meta property="og:title" content="" />
-  </head>
-</html>
-EOS
-            )
-          end
-
-          it 'cannot extract url but can extract domain' do
-            got = @factory.from_page(@page).to_hash
-            expect(got['url']).to eq nil
-            expect(got['domain']).to eq 'awesome.org'
+            expect(got['url']).to eq og_url
           end
         end
       end
@@ -605,6 +512,17 @@ EOS
             expect(got['locale_alternate']).to eq @locale_alternate[0]
             expect(got['site_name']).to eq @site_name
           end
+        end
+      end
+
+      describe 'domain' do
+        before do
+          @page = MetaInspector.new(url, :document => _generate_html([]))
+        end
+
+        it 'can extract domain' do
+          got = @factory.from_page(@page).to_hash
+          expect(got['domain']).to eq domain
         end
       end
     end


### PR DESCRIPTION
fixes #28 

Below are the introduced changed other than the PR title.

- Merged `OpenGraphProperties` and `NonOpenGraphProperties` into a single class named `Properties`
- Refactored and simplified tests