### PR TITLE
Enable the use of non 'link_' prefixed variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,35 +55,35 @@ You can override the default templates used for generating previews, both in cas
 
 2. Use built-in variables to extract data which you would like to render. Available variables are:
     * basic metadata
-        * `{{ link_title }}` for `og:title`
-        * `{{ link_type }}` for `og:type`
-        * `{{ link_image }}` for `og:image`
-        * `{{ link_url }}` for `og:url`
+        * `{{ title }}` for `og:title`
+        * `{{ type }}` for `og:type`
+        * `{{ image }}` for `og:image`
+        * `{{ url }}` for `og:url`
     * optional metadata
-        * `{{ link_description }}` for `og:description`
-        * `{{ link_determiner }}` for `og:determiner`
-        * `{{ link_locale }}` for `og:locale`
-        * `{{ link_locale_alternate }}` for `og:locale:alternate`
-        * `{{ link_site_name }}` for `og:site_name`
+        * `{{ description }}` for `og:description`
+        * `{{ determiner }}` for `og:determiner`
+        * `{{ locale }}` for `og:locale`
+        * `{{ locale_alternate }}` for `og:locale:alternate`
+        * `{{ site_name }}` for `og:site_name`
         * image
-            * `{{ link_image }}` for `og:image`
-            * `{{ link_image_secure_url }}` for `og:image:secure_url`
-            * `{{ link_image_type }}` for `og:image:type`
-            * `{{ link_image_width }}` for `og:image:width`
-            * `{{ link_image_height }}` for `og:image:height`
-            * `{{ link_image_alt }}` for `og:image:alt`
+            * `{{ image }}` for `og:image`
+            * `{{ image_secure_url }}` for `og:image:secure_url`
+            * `{{ image_type }}` for `og:image:type`
+            * `{{ image_width }}` for `og:image:width`
+            * `{{ image_height }}` for `og:image:height`
+            * `{{ image_alt }}` for `og:image:alt`
         * video
-            * `{{ link_video }}` for `og:video`
-            * `{{ link_video_secure_url }}` for `og:video:secure_url`
-            * `{{ link_video_type }}` for `og:video:type`
-            * `{{ link_video_width }}` for `og:video:width`
-            * `{{ link_video_height }}` for `og:video:height`
+            * `{{ video }}` for `og:video`
+            * `{{ video_secure_url }}` for `og:video:secure_url`
+            * `{{ video_type }}` for `og:video:type`
+            * `{{ video_width }}` for `og:video:width`
+            * `{{ video_height }}` for `og:video:height`
         * audio
-            * `{{ link_audio }}` for `og:audio`
-            * `{{ link_audio_secure_url }}` for `og:audio:secure_url`
-            * `{{ link_audio_type }}` for `og:audio:type`
+            * `{{ audio }}` for `og:audio`
+            * `{{ audio_secure_url }}` for `og:audio:secure_url`
+            * `{{ audio_type }}` for `og:audio:type`
     * non og metadata
-        * `{{ link_domain }}`
+        * `{{ domain }}`
 
 ### Template for pages where Open Graph protocol metadata does not exist
 

--- a/lib/jekyll-linkpreview.rb
+++ b/lib/jekyll-linkpreview.rb
@@ -20,6 +20,8 @@ module Jekyll
       def to_hash_for_custom_template()
         hash_for_custom_template = {}
         @properties.each{ |key, value|
+          hash_for_custom_template[key] = value
+          # NOTE: 'link_*' variables will be deleted in v1.0.0.
           hash_for_custom_template['link_' + key] = value
         }
         hash_for_custom_template

--- a/spec/jekyll-linkpreview_spec.rb
+++ b/spec/jekyll-linkpreview_spec.rb
@@ -67,6 +67,12 @@ RSpec.describe 'Jekyll::Linkpreview::Properties' do
   describe '#to_hash_for_custom_template' do
     it 'can return hash for custom template' do
       got = @properties.to_hash_for_custom_template
+      expect(got['title']).to eq @title
+      expect(got['type']).to eq @type
+      expect(got['url']).to eq @url
+      expect(got['image']).to eq @image
+      expect(got['description']).to eq @description
+      expect(got['domain']).to eq @domain
       expect(got['link_title']).to eq @title
       expect(got['link_type']).to eq @type
       expect(got['link_url']).to eq @url
@@ -594,11 +600,16 @@ RSpec.describe 'Jekyll::Linkpreview::LinkpreviewTag' do
         @filepath = File.join source, @tag.template_dir, 'linkpreview.html'
         File.open(@filepath, 'w') { |f| f.write <<-EOS
 <div>
-  <p class="title">{{ link_title }}</p>
-  <p class="url">{{ link_url }}</p>
-  <p class="domain">{{ link_domain }}</p>
-  <p class="image">{{ link_image }}</p>
-  <p class="description">{{ link_description }}</p>
+  <p class="title">{{ title }}</p>
+  <p class="url">{{ url }}</p>
+  <p class="domain">{{ domain }}</p>
+  <p class="image">{{ image }}</p>
+  <p class="description">{{ description }}</p>
+  <p class="link_title">{{ link_title }}</p>
+  <p class="link_url">{{ link_url }}</p>
+  <p class="link_domain">{{ link_domain }}</p>
+  <p class="link_image">{{ link_image }}</p>
+  <p class="link_description">{{ link_description }}</p>
 </div>
 EOS
         }
@@ -608,10 +619,14 @@ EOS
         @filepath = File.join source, @tag.template_dir, 'linkpreview_nog.html'
         File.open(@filepath, 'w') { |f| f.write <<-EOS
 <div>
-  <p class="title">{{ link_title }}</p>
-  <p class="url">{{ link_url }}</p>
-  <p class="domain">{{ link_domain }}</p>
-  <p class="description">{{ link_description }}</p>
+  <p class="title">{{ title }}</p>
+  <p class="url">{{ url }}</p>
+  <p class="domain">{{ domain }}</p>
+  <p class="description">{{ description }}</p>
+  <p class="link_title">{{ link_title }}</p>
+  <p class="link_url">{{ link_url }}</p>
+  <p class="link_domain">{{ link_domain }}</p>
+  <p class="link_description">{{ link_description }}</p>
 </div>
 EOS
         }
@@ -643,6 +658,11 @@ EOS
             expect(doc.xpath('//p[@class="domain"]').inner_text).to eq @domain
             expect(doc.xpath('//p[@class="image"]').inner_text).to eq @image
             expect(doc.xpath('//p[@class="description"]').inner_text).to eq @description
+            expect(doc.xpath('//p[@class="link_title"]').inner_text).to eq @title
+            expect(doc.xpath('//p[@class="link_url"]').inner_text).to eq @url
+            expect(doc.xpath('//p[@class="link_domain"]').inner_text).to eq @domain
+            expect(doc.xpath('//p[@class="link_image"]').inner_text).to eq @image
+            expect(doc.xpath('//p[@class="link_description"]').inner_text).to eq @description
           end
         end
 
@@ -687,6 +707,10 @@ EOS
             expect(doc.xpath('//p[@class="url"]').inner_text).to eq @url
             expect(doc.xpath('//p[@class="domain"]').inner_text).to eq @domain
             expect(doc.xpath('//p[@class="description"]').inner_text).to eq @description
+            expect(doc.xpath('//p[@class="link_title"]').inner_text).to eq @title
+            expect(doc.xpath('//p[@class="link_url"]').inner_text).to eq @url
+            expect(doc.xpath('//p[@class="link_domain"]').inner_text).to eq @domain
+            expect(doc.xpath('//p[@class="link_description"]').inner_text).to eq @description
           end
         end
 

--- a/spec/jekyll-linkpreview_spec.rb
+++ b/spec/jekyll-linkpreview_spec.rb
@@ -589,6 +589,32 @@ RSpec.describe 'Jekyll::Linkpreview::LinkpreviewTag' do
         expect(doc.xpath('//div[@class="jekyll-linkpreview-description"]').inner_text).to eq @description
       end
 
+      def check_if_custom_template_for_ogp_pages_is_rendered(html)
+        doc = Nokogiri::HTML.parse(html, nil, 'utf-8')
+        expect(doc.xpath('//p[@class="title"]').inner_text).to eq @title
+        expect(doc.xpath('//p[@class="url"]').inner_text).to eq @url
+        expect(doc.xpath('//p[@class="domain"]').inner_text).to eq @domain
+        expect(doc.xpath('//p[@class="image"]').inner_text).to eq @image
+        expect(doc.xpath('//p[@class="description"]').inner_text).to eq @description
+        expect(doc.xpath('//p[@class="link_title"]').inner_text).to eq @title
+        expect(doc.xpath('//p[@class="link_url"]').inner_text).to eq @url
+        expect(doc.xpath('//p[@class="link_domain"]').inner_text).to eq @domain
+        expect(doc.xpath('//p[@class="link_image"]').inner_text).to eq @image
+        expect(doc.xpath('//p[@class="link_description"]').inner_text).to eq @description
+      end
+
+      def check_if_custom_template_for_non_ogp_pages_is_rendered(html)
+        doc = Nokogiri::HTML.parse(html, nil, 'utf-8')
+        expect(doc.xpath('//p[@class="title"]').inner_text).to eq @title
+        expect(doc.xpath('//p[@class="url"]').inner_text).to eq @url
+        expect(doc.xpath('//p[@class="domain"]').inner_text).to eq @domain
+        expect(doc.xpath('//p[@class="description"]').inner_text).to eq @description
+        expect(doc.xpath('//p[@class="link_title"]').inner_text).to eq @title
+        expect(doc.xpath('//p[@class="link_url"]').inner_text).to eq @url
+        expect(doc.xpath('//p[@class="link_domain"]').inner_text).to eq @domain
+        expect(doc.xpath('//p[@class="link_description"]').inner_text).to eq @description
+      end
+
       def get_context(source_dir)
         config = { 'source' => source_dir, 'skip_config_files' => 'true' }
         Liquid::Context.new({}, {}, {
@@ -652,17 +678,7 @@ EOS
           end
           it 'can render custom template' do
             html = @tag.render get_context(source)
-            doc = Nokogiri::HTML.parse(html, nil, 'utf-8')
-            expect(doc.xpath('//p[@class="title"]').inner_text).to eq @title
-            expect(doc.xpath('//p[@class="url"]').inner_text).to eq @url
-            expect(doc.xpath('//p[@class="domain"]').inner_text).to eq @domain
-            expect(doc.xpath('//p[@class="image"]').inner_text).to eq @image
-            expect(doc.xpath('//p[@class="description"]').inner_text).to eq @description
-            expect(doc.xpath('//p[@class="link_title"]').inner_text).to eq @title
-            expect(doc.xpath('//p[@class="link_url"]').inner_text).to eq @url
-            expect(doc.xpath('//p[@class="link_domain"]').inner_text).to eq @domain
-            expect(doc.xpath('//p[@class="link_image"]').inner_text).to eq @image
-            expect(doc.xpath('//p[@class="link_description"]').inner_text).to eq @description
+            check_if_custom_template_for_ogp_pages_is_rendered html
           end
         end
 
@@ -702,15 +718,7 @@ EOS
           end
           it 'can render custom template' do
             html = @tag.render get_context(source)
-            doc = Nokogiri::HTML.parse(html, nil, 'utf-8')
-            expect(doc.xpath('//p[@class="title"]').inner_text).to eq @title
-            expect(doc.xpath('//p[@class="url"]').inner_text).to eq @url
-            expect(doc.xpath('//p[@class="domain"]').inner_text).to eq @domain
-            expect(doc.xpath('//p[@class="description"]').inner_text).to eq @description
-            expect(doc.xpath('//p[@class="link_title"]').inner_text).to eq @title
-            expect(doc.xpath('//p[@class="link_url"]').inner_text).to eq @url
-            expect(doc.xpath('//p[@class="link_domain"]').inner_text).to eq @domain
-            expect(doc.xpath('//p[@class="link_description"]').inner_text).to eq @description
+            check_if_custom_template_for_non_ogp_pages_is_rendered html
           end
         end
 

--- a/spec/jekyll-linkpreview_spec.rb
+++ b/spec/jekyll-linkpreview_spec.rb
@@ -569,7 +569,7 @@ RSpec.describe 'Jekyll::Linkpreview::LinkpreviewTag' do
         FileUtils.rm_r File.join(source, @tag.template_dir)
       end
 
-      def check_default_template_with_image_is_rendered(html)
+      def check_if_default_template_with_image_is_rendered(html)
         doc = Nokogiri::HTML.parse(html, nil, 'utf-8')
         expect(doc.xpath('//h2[@class="jekyll-linkpreview-title"]/a').inner_text).to eq @title
         expect(doc.xpath('//h2[@class="jekyll-linkpreview-title"]/a').attribute('href').value).to eq @url
@@ -579,7 +579,7 @@ RSpec.describe 'Jekyll::Linkpreview::LinkpreviewTag' do
         expect(doc.xpath('//div[@class="jekyll-linkpreview-description"]').inner_text).to eq @description
       end
 
-      def check_default_template_without_image_is_rendered(html)
+      def check_if_default_template_without_image_is_rendered(html)
         doc = Nokogiri::HTML.parse(html, nil, 'utf-8')
         expect(doc.xpath('//h2[@class="jekyll-linkpreview-title"]/a').inner_text).to eq @title
         expect(doc.xpath('//h2[@class="jekyll-linkpreview-title"]/a').attribute('href').value).to eq @url
@@ -688,14 +688,14 @@ EOS
           end
           it 'cannot render custom template' do
             html = @tag.render get_context(source)
-            check_default_template_with_image_is_rendered html
+            check_if_default_template_with_image_is_rendered html
           end
         end
 
         context 'when no custom template file exists' do
           it 'cannot render custom template' do
             html = @tag.render get_context(source)
-            check_default_template_with_image_is_rendered html
+            check_if_default_template_with_image_is_rendered html
           end
         end
       end
@@ -728,14 +728,14 @@ EOS
           end
           it 'cannot render custom template' do
             html = @tag.render get_context(source)
-            check_default_template_without_image_is_rendered html
+            check_if_default_template_without_image_is_rendered html
           end
         end
 
         context 'when no custom template file exists' do
           it 'cannot render custom template' do
             html = @tag.render get_context(source)
-            check_default_template_without_image_is_rendered html
+            check_if_default_template_without_image_is_rendered html
           end
         end
       end


### PR DESCRIPTION
Now users can use `{{ title }}` as well as `{{ link_title }}` in a custom template.

**Deprecation warning**: all `link_*` variables will be deleted in v1.0.0.