### PR TITLE
Bump version to 0.7.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,7 +49,7 @@ jobs:
           chmod 0600 ~/.gem/credentials
       - name: Configure git
         run: |
-          git config --global user.email "yusuke.nishioka.0713@gmail..com"
+          git config --global user.email "yusuke.nishioka.0713@gmail.com"
           git config --global user.name "Yusuke Nishioka"
       - name: Install dependencies
         run: bundle install

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 2
       # See https://github.com/actions/runner-images/issues/6775.
       - name: Suppress 'detected dubious ownership' error.
-        run: git config --global --add safe.directory /__w/jekyll-linkpreview/jekyll-linkpreview
+        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
       - id: check-release
         name: Decide whether to release
         run: |
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v3
       # See https://github.com/actions/runner-images/issues/6775.
       - name: Suppress 'detected dubious ownership' error.
-        run: git config --global --add safe.directory /__w/jekyll-linkpreview/jekyll-linkpreview
+        run: git config --global --add safe.directory ${GITHUB_WORKSPACE}
       - env:
           RUBYGEMS_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
         name: Set credentials for RubyGems

--- a/README.md
+++ b/README.md
@@ -93,10 +93,10 @@ You can override the default templates used for generating previews, both in cas
       Therefore, it *must* be under the [site's source](https://jekyllrb.com/docs/configuration/options/).
 
 2. Use built-in variables to extract data which you would like to render. Available variables are:
-    * `{{ link_title }}`
-    * `{{ link_url }}`
-    * `{{ link_description }}`
-    * `{{ link_domain }}`
+    * `{{ title }}`
+    * `{{ url }}`
+    * `{{ description }}`
+    * `{{ domain }}`
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Jekyll::Linkpreview
 
-[![Build Status](https://travis-ci.com/ysk24ok/jekyll-linkpreview.svg?branch=master)](https://travis-ci.com/ysk24ok/jekyll-linkpreview)
+[![Test](https://github.com/ysk24ok/jekyll-linkpreview/actions/workflows/test.yaml/badge.svg)](https://github.com/ysk24ok/jekyll-linkpreview/actions/workflows/test.yaml)
+[![Release](https://github.com/ysk24ok/jekyll-linkpreview/actions/workflows/release.yaml/badge.svg)](https://github.com/ysk24ok/jekyll-linkpreview/actions/workflows/release.yaml)
 
 Jekyll plugin to generate link preview by `{% linkpreview %}` tag. The plugin fetches [Open Graph protocol](http://ogp.me/) metadata of the designated page to generate preview. The og properties are saved as JSON for caching and it is used when rebuilding the site.
 

--- a/lib/jekyll-linkpreview/version.rb
+++ b/lib/jekyll-linkpreview/version.rb
@@ -1,5 +1,5 @@
 module Jekyll
   module Linkpreview
-    VERSION = "0.6.0"
+    VERSION = "0.7.0"
   end
 end


### PR DESCRIPTION
Also several fixes are included

- Updated CI badges, which should have been done in #33 
- Updated template variable list for non ogp pages, which should have been done in #51 
- Fix email in `release` workflow, which was caused by #35 
- Replaced `/__w/jekyll-linkpreview/jekyll-linkpreview` with `GITHUB_WORKSPACE`, which was caused by #47 