### PR TITLE
Use appraisal ~> 2.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,12 +2,3 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in jekyll-linkpreview.gemspec
 gemspec
-
-# The issue that appraisal 2.4.1 can't work with bundler >= 2.4 was solved
-# (see https://github.com/thoughtbot/appraisal/issues/199 for details),
-# but a new version has not been released yet as of Apr 2023.
-# As it's not possible to install a gem from a git repository in the gemspec file,
-# appraisal is being installed in Gemfile.
-group :development do
-  gem 'appraisal', git: 'https://github.com/thoughtbot/appraisal'
-end

--- a/jekyll-linkpreview.gemspec
+++ b/jekyll-linkpreview.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "jekyll", ">= 3.5", "< 5.0"
   spec.add_dependency "metainspector", "~> 5.9"
+  spec.add_development_dependency "appraisal", "~> 2.5"
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.0"


### PR DESCRIPTION
Since the fixes for https://github.com/thoughtbot/appraisal/issues/199 became available in appraisal 2.5.0, I'm moving the installation to .gemspec and updating the version.